### PR TITLE
V3.0.1/update snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubAdmin
 Title: Utilities for administering hubverse Hubs
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: 
     c(person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# hubAdmin 1.0.1
+
+* Update `create_output_type_cdf()` to accommodate less restrictive `output_type_id` checks introduced in schema version [`v3.0.1`](https://github.com/hubverse-org/schemas/releases/tag/v3.0.1).
+
 # hubAdmin 1.0.0
 
 * Breaking changes: Support schema v3.0.0 specification of sample output type IDs which are now specified through a `output_type_id_params` object instead of `output_type_id`. The main breaking change is in `create_output_type_sample()` which now takes arguments incompatible with previous schema versions and returns an object with an `output_type_id_params` object instead of `output_type_id`. Additional but back-compatible dynamic validation checks on sample output types have been added to `validate_config()`.

--- a/R/check_input.R
+++ b/R/check_input.R
@@ -335,10 +335,9 @@ check_oneof_input <- function(input, property = c("required", "optional"), # nol
 
   if (typeof(input) == "character") {
     value_schema <- oneof_schema[["character"]]
-    if (!is.null(value_schema[["pattern"]]) && !any(
-      grepl(value_schema[["pattern"]], input)
-    )
-    ) {
+    unmatched_values_exist <- !is.null(value_schema[["pattern"]] &&
+      !any(grepl(value_schema[["pattern"]], input))
+    if (unmatched_values_exist) {
       cli::cli_abort(
         c(
           "x" = "Values of {.arg {property}} must match regex pattern

--- a/R/check_input.R
+++ b/R/check_input.R
@@ -335,7 +335,9 @@ check_oneof_input <- function(input, property = c("required", "optional"), # nol
 
   if (typeof(input) == "character") {
     value_schema <- oneof_schema[["character"]]
-    if (!any((grepl(value_schema[["pattern"]], input)))) {
+    if (!is.null(value_schema[["pattern"]]) &&
+        !any((grepl(value_schema[["pattern"]], input)))
+        ) {
       cli::cli_abort(
         c(
           "x" = "Values of {.arg {property}} must match regex pattern

--- a/R/check_input.R
+++ b/R/check_input.R
@@ -335,9 +335,10 @@ check_oneof_input <- function(input, property = c("required", "optional"), # nol
 
   if (typeof(input) == "character") {
     value_schema <- oneof_schema[["character"]]
-    if (!is.null(value_schema[["pattern"]]) &&
-        !any((grepl(value_schema[["pattern"]], input)))
-        ) {
+    if (!is.null(value_schema[["pattern"]]) && !any(
+      grepl(value_schema[["pattern"]], input)
+    )
+    ) {
       cli::cli_abort(
         c(
           "x" = "Values of {.arg {property}} must match regex pattern

--- a/R/check_input.R
+++ b/R/check_input.R
@@ -335,7 +335,7 @@ check_oneof_input <- function(input, property = c("required", "optional"), # nol
 
   if (typeof(input) == "character") {
     value_schema <- oneof_schema[["character"]]
-    unmatched_values_exist <- !is.null(value_schema[["pattern"]] &&
+    unmatched_values_exist <- !is.null(value_schema[["pattern"]]) &&
       !any(grepl(value_schema[["pattern"]], input))
     if (unmatched_values_exist) {
       cli::cli_abort(

--- a/tests/testthat/_snaps/create_config.md
+++ b/tests/testthat/_snaps/create_config.md
@@ -4,7 +4,7 @@
       create_config(rounds)
     Output
       $schema_version
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
       
       $rounds
       $rounds[[1]]
@@ -105,7 +105,7 @@
       attr(,"class")
       [1] "config" "list"  
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_config functions error correctly
 

--- a/tests/testthat/_snaps/create_model_task.md
+++ b/tests/testthat/_snaps/create_model_task.md
@@ -85,7 +85,7 @@
       attr(,"class")
       [1] "model_task" "list"      
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -211,7 +211,7 @@
       attr(,"class")
       [1] "model_task" "list"      
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -375,7 +375,7 @@
       attr(,"class")
       [1] "model_task" "list"      
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_output_type_point functions error correctly
 
@@ -434,8 +434,8 @@
       x `schema_id` attributes are not consistent across all arguments.
       Argument `schema_id` attributes:
       * task_ids : invalid_schema_id
-      * output_type : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
-      * target_metadata : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
+      * output_type : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
+      * target_metadata : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
 
 ---
 

--- a/tests/testthat/_snaps/create_model_tasks.md
+++ b/tests/testthat/_snaps/create_model_tasks.md
@@ -92,7 +92,7 @@
       attr(,"n")
       [1] 1
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -361,7 +361,7 @@
       attr(,"n")
       [1] 2
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_model_tasks functions error correctly
 
@@ -393,5 +393,5 @@
       x `schema_id` attributes are not consistent across all items.
       Item `schema_id` attributes:
       * Item 1 : invalid_schema_id
-      * Item 2 : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
+      * Item 2 : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
 

--- a/tests/testthat/_snaps/create_output_type.md
+++ b/tests/testthat/_snaps/create_output_type.md
@@ -65,7 +65,7 @@
       attr(,"n")
       [1] 3
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_output_type functions error correctly
 

--- a/tests/testthat/_snaps/create_output_type_item.md
+++ b/tests/testthat/_snaps/create_output_type_item.md
@@ -25,7 +25,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -54,7 +54,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -79,7 +79,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -177,7 +177,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -208,7 +208,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -240,7 +240,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -272,7 +272,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -312,7 +312,7 @@
 
     Code
       create_output_type_cdf(required = NULL, optional = c("EW202240", "EW202241",
-        "EW2022423"), value_type = "double")
+        "EW2022423"), value_type = "double", schema_version = "v3.0.0")
     Condition
       Error in `map()`:
       i In index: 2.
@@ -368,7 +368,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -414,7 +414,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_output_type_sample errors correctly
 

--- a/tests/testthat/_snaps/create_round.md
+++ b/tests/testthat/_snaps/create_round.md
@@ -102,7 +102,7 @@
       attr(,"round_id")
       [1] "round_1"
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -211,7 +211,7 @@
       attr(,"round_id")
       [1] "origin_date"
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_round name matching works correctly
 

--- a/tests/testthat/_snaps/create_rounds.md
+++ b/tests/testthat/_snaps/create_rounds.md
@@ -106,7 +106,7 @@
       attr(,"n")
       [1] 1
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -331,7 +331,7 @@
       attr(,"n")
       [1] 2
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_round errors correctly
 

--- a/tests/testthat/_snaps/create_target_metadata.md
+++ b/tests/testthat/_snaps/create_target_metadata.md
@@ -66,7 +66,7 @@
       attr(,"n")
       [1] 2
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_target_metadata functions error correctly
 
@@ -123,5 +123,5 @@
       x `schema_id` attributes are not consistent across all items.
       Item `schema_id` attributes:
       * Item 1 : invalid_schema
-      * Item 2 : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
+      * Item 2 : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
 

--- a/tests/testthat/_snaps/create_target_metadata_item.md
+++ b/tests/testthat/_snaps/create_target_metadata_item.md
@@ -31,7 +31,7 @@
       attr(,"class")
       [1] "target_metadata_item" "list"                
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -61,7 +61,7 @@
       attr(,"class")
       [1] "target_metadata_item" "list"                
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_target_metadata_item functions error correctly
 

--- a/tests/testthat/_snaps/create_task_id.md
+++ b/tests/testthat/_snaps/create_task_id.md
@@ -14,7 +14,7 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -33,7 +33,7 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -52,7 +52,7 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -70,7 +70,7 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 ---
 
@@ -88,7 +88,7 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_task_id errors correctly
 

--- a/tests/testthat/_snaps/create_task_ids.md
+++ b/tests/testthat/_snaps/create_task_ids.md
@@ -55,7 +55,7 @@
       attr(,"n")
       [1] 5
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
+      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
 
 # create_task_ids functions error correctly
 
@@ -89,5 +89,5 @@
       x `schema_id` attributes are not consistent across all items.
       Item `schema_id` attributes:
       * Item 1 : invalid_schema
-      * Item 2 : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
+      * Item 2 : https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
 

--- a/tests/testthat/_snaps/validate_config.md
+++ b/tests/testthat/_snaps/validate_config.md
@@ -7,9 +7,9 @@
       attr(,"config_path")
       [1] "testdata/tasks-samples-pass.json"
       attr(,"schema_version")
-      [1] "v3.0.0"
+      [1] "v3.0.1"
       attr(,"schema_url")
-      https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
+      https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
 
 # Config for samples fail correctly
 
@@ -20,9 +20,9 @@
       attr(,"config_path")
       [1] "testdata/tasks-samples-error-range.json"
       attr(,"schema_version")
-      [1] "v3.0.0"
+      [1] "v3.0.1"
       attr(,"schema_url")
-      https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
+      https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
       attr(,"errors")
                                                                      instancePath
       1 /rounds/0/model_tasks/0/task_ids/output_type/sample/output_type_id_params
@@ -44,9 +44,9 @@
       attr(,"config_path")
       [1] "testdata/tasks-samples-error-task-ids.json"
       attr(,"schema_version")
-      [1] "v3.0.0"
+      [1] "v3.0.1"
       attr(,"schema_url")
-      https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json
+      https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json
       attr(,"errors")
                                                                                          instancePath
       1 /rounds/0/model_tasks/0/task_ids/output_type/sample/output_type_id_params/compound_taskid_set

--- a/tests/testthat/test-create_output_type_item.R
+++ b/tests/testthat/test-create_output_type_item.R
@@ -125,7 +125,8 @@ test_that("create_output_type_dist functions error correctly", {
         "EW202241",
         "EW2022423"
       ),
-      value_type = "double"
+      value_type = "double",
+      schema_version = "v3.0.0"
     ),
     error = TRUE
   )


### PR DESCRIPTION
This PR checks and updates all test snapshots to latest schema version.

Also ensures that `create_output_type_cdf()` can accommodate the less restrictive `output_type_id` checks introduced in schema version [`v3.0.1`](https://github.com/hubverse-org/schemas/releases/tag/v3.0.1).