### PR TITLE
release 1.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,14 @@
 # hubAdmin 1.0.1
 
-* Update `create_output_type_cdf()` to accommodate less restrictive `output_type_id` checks introduced in schema version [`v3.0.1`](https://github.com/hubverse-org/schemas/releases/tag/v3.0.1).
+* Update `create_output_type_cdf()` to accommodate less restrictive
+  `output_type_id` checks introduced in schema version
+  [`v3.0.1`](https://github.com/hubverse-org/schemas/releases/tag/v3.0.1)
+  (implemented: @annakrystalli, #29).
+* URL for hubdocs updated (@zkamvar, #27)
+* Output of `validate_config()` and `validate_hub_config()` are now classed so
+  the summary of their contents is printed nicely to the screen, reducing the
+  amount of screen space needed to report success or failure (suggested: 
+  @zkamvar, #32; implemented: @zkamvar, #35)
 
 # hubAdmin 1.0.0
 


### PR DESCRIPTION
This cleans up the news, adding PR references to release version 1.0.1 to the r-universe

This is a bit of a release in name only since these features already exist on the version that's on the r-universe, but this is also partially an example of how the releases would work. 
