### PR TITLE
Release 1.0.2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: hubAdmin
 Title: Utilities for Administering Hubverse Hubs
-Version: 1.0.1.9000
+Version: 1.0.2
 Authors@R: c(
     person("Anna", "Krystalli", , "annakrystalli@googlemail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-2378-4915")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# hubAdmin (development)
+# hubAdmin 1.0.2
 
 * New feature: Add `ci_validate_hub_config()` as a non-interactive function that works with
   GitHub to produce a validation report on Continous Integration (#37)

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,7 +29,7 @@ This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem
 
 ## Installation
 
-> [!NOTE]
+> [!NOTE]    
 > If you have any problems with installation of package `V8` (more likely on Linux), please consult the [V8 installation instructions](https://github.com/jeroen/V8#installation).
 
 ### Latest

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,6 +18,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![hubAdmin status badge](https://hubverse-org.r-universe.dev/badges/hubAdmin)](https://hubverse-org.r-universe.dev/hubAdmin)
 [![CRAN status](https://www.r-pkg.org/badges/version/hubAdmin)](https://CRAN.R-project.org/package=hubAdmin)
 [![R-CMD-check](https://github.com/hubverse-org/hubAdmin/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/hubverse-org/hubAdmin/actions/workflows/R-CMD-check.yaml)
 <!-- badges: end -->
@@ -28,15 +29,25 @@ This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem
 
 ## Installation
 
-You can install the development version of hubAdmin from [GitHub](https://github.com/) with:
+> [!Note]
+> If you have any problems with installation of package `V8` (more likely on Linux), please consult the [V8 installation instructions](https://github.com/jeroen/V8#installation).
+
+### Latest
+
+You can install the [latest version of hubAdmin from the R-universe](https://hubverse-org.r-universe.dev/hubAdmin):
+
+``` r
+install.packages("hubAdmin", repos = c("https://hubverse-org.r-universe.dev", "https://cloud.r-project.org"))
+```
+
+### Development
+
+If you want to test out new features that have not yet been released, you can install the development version of hubAdmin from [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("remotes")
 remotes::install_github("hubverse-org/hubAdmin")
 ```
-
-> #####  **Note:**
-> If you have any problems with installation of package `V8` (more likely on Linux), please consult the [following installation instructions](https://github.com/jeroen/V8#installation).
 
 ***
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,7 +29,7 @@ This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem
 
 ## Installation
 
-> [!Note]
+> [!NOTE]
 > If you have any problems with installation of package `V8` (more likely on Linux), please consult the [V8 installation instructions](https://github.com/jeroen/V8#installation).
 
 ### Latest

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ modeling hubs to share and collaborate on their work.
 
 ## Installation
 
-> [!Note] If you have any problems with installation of package `V8`
+> [!NOTE] If you have any problems with installation of package `V8`
 > (more likely on Linux), please consult the [V8 installation
 > instructions](https://github.com/jeroen/V8#installation).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ modeling hubs to share and collaborate on their work.
 
 ## Installation
 
-> [!NOTE] If you have any problems with installation of package `V8`
+> [!NOTE] 
+> If you have any problems with installation of package `V8`
 > (more likely on Linux), please consult the [V8 installation
 > instructions](https://github.com/jeroen/V8#installation).
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [![Lifecycle:
 experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![hubAdmin status
+badge](https://hubverse-org.r-universe.dev/badges/hubAdmin)](https://hubverse-org.r-universe.dev/hubAdmin)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/hubAdmin)](https://CRAN.R-project.org/package=hubAdmin)
 [![R-CMD-check](https://github.com/hubverse-org/hubAdmin/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/hubverse-org/hubAdmin/actions/workflows/R-CMD-check.yaml)
@@ -15,26 +17,35 @@ status](https://www.r-pkg.org/badges/version/hubAdmin)](https://CRAN.R-project.o
 The goal of hubAdmin is to provide a set of utility functions for
 administering hubverse Hubs.
 
-This package is part of the
-[hubverse](https://hubverse.io/en/latest/) ecosystem, which
-aims to provide a set of tools for infectious disease modeling hubs to
-share and collaborate on their work.
+This package is part of the [hubverse](https://hubverse.io/en/latest/)
+ecosystem, which aims to provide a set of tools for infectious disease
+modeling hubs to share and collaborate on their work.
 
 ## Installation
 
-You can install the development version of hubAdmin from
+> [!Note] If you have any problems with installation of package `V8`
+> (more likely on Linux), please consult the [V8 installation
+> instructions](https://github.com/jeroen/V8#installation).
+
+### Latest
+
+You can install the [latest version of hubAdmin from the
+R-universe](https://hubverse-org.r-universe.dev/hubAdmin):
+
+``` r
+install.packages("hubAdmin", repos = c("https://hubverse-org.r-universe.dev", "https://cloud.r-project.org"))
+```
+
+### Development
+
+If you want to test out new features that have not yet been released,
+you can install the development version of hubAdmin from
 [GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("remotes")
 remotes::install_github("hubverse-org/hubAdmin")
 ```
-
-> ##### **Note:**
->
-> If you have any problems with installation of package `V8` (more
-> likely on Linux), please consult the [following installation
-> instructions](https://github.com/jeroen/V8#installation).
 
 ------------------------------------------------------------------------
 
@@ -48,5 +59,5 @@ project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html)
-or [how to contribute to the hubAdmin package](.github/CONTRIBUTING.md).
+Community](https://hubverse.io/en/latest/overview/contribute.html) or
+[how to contribute to the hubAdmin package](.github/CONTRIBUTING.md).


### PR DESCRIPTION
This will release 1.0.2, which contains the new `ci_validate_hub_config()` function and does the following:

 - bumps the version number
 - updates the README with installation instructions

### Next steps

 - [ ] tag and release
 - [ ] update `validate-config` action from https://github.com/hubverse-org/hubverse-actions

### Demonstration PR

This is also an example of a release pull request aligned with the guidelines in https://github.com/orgs/hubverse-org/discussions/29. 

Last week, I set this repository to be sent to the R universe upon GitHub release: https://github.com/hubverse-org/hubverse-org.r-universe.dev/commit/82376c509b4f1992c19879906c5bdab7b1c48725

When #37 was merged into main, it was merged as a development feature and when this PR is merged, I will create a tag and release, which will update the R universe.

Since this is a demonstration, after I release the package, I will revert https://github.com/hubverse-org/hubverse-org.r-universe.dev/commit/82376c509b4f1992c19879906c5bdab7b1c48725 to go back to our original release-from-main workflow until I have sufficiently updated the documentation and addressed developer concerns.  