### PR TITLE
Add tests for validating target keys are strings, not arrays. (#54)

### DIFF
--- a/tests/testthat/_snaps/validate_config.md
+++ b/tests/testthat/_snaps/validate_config.md
@@ -915,3 +915,67 @@
     Output
       NULL
 
+# target keys error if arrays passed
+
+    Code
+      out_v4
+    Output
+      [1] FALSE
+    Message
+      ! 1 schema errors: testdata/tasks-target-key-array-v4.json
+        (<file://testdata/tasks-target-key-array-v4.json>) (via tasks-schema v4.0.0
+        (<https://raw.githubusercontent.com/hubverse-org/schemas/br-v4.0.0/v4.0.0/tasks-schema.json>))
+      i use `view_config_val_errors()` to view table of error details.
+
+---
+
+    Code
+      attr(out_v4, "errors")
+    Output
+                                                        instancePath
+      1 /rounds/0/model_tasks/0/target_metadata/0/target_keys/target
+                                                                                                                                      schemaPath
+      1 #/properties/rounds/items/properties/model_tasks/items/properties/target_metadata/items/properties/target_keys/additionalProperties/type
+        keyword   type        message schema   type                      data
+      1    type string must be string string string wk flu hosp rate category
+                                                            dataPath
+      1 /rounds/0/model_tasks/0/target_metadata/0/target_keys/target
+
+---
+
+    Code
+      attr(out_v3, "errors")
+    Output
+                                                  instancePath
+      1 /rounds/0/model_tasks/0/output_type/pmf/output_type_id
+                                                                                                                             schemaPath
+      1 #/properties/rounds/items/properties/model_tasks/items/properties/output_type/properties/pmf/properties/output_type_id/required
+         keyword missingProperty                                message
+      1 required        optional must have required property 'optional'
+                    schema
+      1 required, optional
+                                                                                                                                                                                   parentSchema.description
+      1 Object containing required and optional arrays specifying valid categories of a discrete variable. Note that for ordinal variables, the category levels should be listed in order from low to high.
+                   parentSchema.examples parentSchema.type
+      1 NA, low, moderate, high, extreme            object
+                                                                                                                                                                         parentSchema.properties.required.description
+      1 Array of unique categories of a discrete variable that must be present for submission to be valid. Can be null if no categories are required and all valid categories are specified in the optional property.
+        parentSchema.properties.required.type
+      1                           array, null
+        parentSchema.properties.required.uniqueItems
+      1                                         TRUE
+        parentSchema.properties.required.type
+      1                                string
+                                                                                                                            parentSchema.properties.optional.description
+      1 Array of valid but not required unique categories of a discrete variable. Can be null if all categories are required and are specified in the required property.
+        parentSchema.properties.optional.type
+      1                           array, null
+        parentSchema.properties.optional.uniqueItems
+      1                                         TRUE
+        parentSchema.properties.optional.type parentSchema.required
+      1                                string    required, optional
+                              required
+      1 low, moderate, high, very high
+                                                      dataPath
+      1 /rounds/0/model_tasks/0/output_type/pmf/output_type_id
+

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -26,8 +26,10 @@ test_that("Config validated successfully", {
 
 test_that("Config for samples handled succesfully", {
   config_path <- testthat::test_path("testdata", "tasks-samples-pass.json")
-  out <- suppressMessages(validate_config(config_path = config_path,
-                                          schema_version = "latest"))
+  out <- suppressMessages(validate_config(
+    config_path = config_path,
+    schema_version = "latest"
+  ))
   expect_snapshot(out)
   expect_true(out)
 })
@@ -40,15 +42,19 @@ test_that("Missing files returns an invalid config with an immediate message", {
 })
 test_that("Config for samples fail correctly", {
   config_path <- testthat::test_path("testdata", "tasks-samples-error-range.json")
-  out <- suppressWarnings(validate_config(config_path = config_path,
-                                          schema_version = "latest"))
+  out <- suppressWarnings(validate_config(
+    config_path = config_path,
+    schema_version = "latest"
+  ))
   expect_snapshot(out)
   expect_snapshot(attr(out, "errors"))
   expect_false(out)
 
   config_path <- testthat::test_path("testdata", "tasks-samples-error-task-ids.json")
-  out <- suppressWarnings(validate_config(config_path = config_path,
-                                          schema_version = "latest"))
+  out <- suppressWarnings(validate_config(
+    config_path = config_path,
+    schema_version = "latest"
+  ))
   expect_snapshot(out)
   expect_snapshot(attr(out, "errors"))
   expect_false(out)
@@ -63,7 +69,6 @@ test_that("Config errors detected successfully", {
   expect_snapshot(attr(out, "errors"))
   expect_false(out)
 })
-
 
 
 test_that("Dynamic config errors detected successfully by custom R validation", {
@@ -157,4 +162,30 @@ test_that("Old orgname config validates successfully", {
   expect_snapshot(out)
   expect_snapshot(attr(out, "errors"))
   expect_true(out)
+})
+
+test_that("target keys error if arrays passed", {
+  config_path <- testthat::test_path(
+    "testdata",
+    "tasks-target-key-array-v4.json"
+  )
+  # TODO: remove branch argument when v4.0.0 is released.
+  out_v4 <- suppressMessages(validate_config(
+    config_path = config_path,
+    schema_version = "v4.0.0",
+    branch = "br-v4.0.0"
+  ))
+  expect_snapshot(out_v4)
+  # latest schema should throw error with respect to target key type.
+  expect_snapshot(attr(out_v4, "errors"))
+  expect_false(out_v4)
+
+  out_v3 <- suppressMessages(validate_config(
+    config_path = config_path,
+    schema_version = "v3.0.0"
+  ))
+  # v3.0.0 schema should throw error about missing optional property in pmf
+  # but not about target keys.
+  expect_snapshot(attr(out_v3, "errors"))
+  expect_false(out_v3)
 })

--- a/tests/testthat/testdata/tasks-target-key-array-v4.json
+++ b/tests/testthat/testdata/tasks-target-key-array-v4.json
@@ -1,0 +1,76 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/Infectious-Disease-Modeling-Hubs/schemas/main/v4.0.0/tasks-schema.json",
+    "rounds": [
+        {
+            "round_id_from_variable": true,
+            "round_id": "reference_date",
+            "model_tasks": [
+                {
+                    "task_ids": {
+                        "reference_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-10-22", "2022-10-29", "2022-11-05"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": ["wk flu hosp rate category"]
+                        },
+                        "horizon": {
+                            "required": null,
+                            "optional": [0, 1, 2, 3]
+                        },
+                        "location": {
+                            "required": null,
+                            "optional": [
+                                "US",
+                                "01",
+                                "02"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "pmf": {
+                            "output_type_id": {
+                                "required": [
+                                    "low",
+                                    "moderate",
+                                    "high",
+                                    "very high"
+                                ]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0,
+                                "maximum": 1
+                            },
+                            "is_required": true
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "wk flu hosp rate category",
+                            "target_name": "week ahead weekly influenza hospitalization rate category",
+                            "target_units": "rate per 100,000 population",
+                            "target_keys": {
+                                "target": [
+                                    "wk flu hosp rate category"
+                                ]
+                            },
+                            "target_type": "ordinal",
+                            "description": "This target represents a categorical severity level for rate of new hospitalizations per week for the week ending [horizon] weeks after the reference_date, on target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                }
+            ],
+            "submissions_due": {
+                "relative_to": "reference_date",
+                "start": -6,
+                "end": -3
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add tests for validating target keys are strings, not arrays. Resolves #54