### PR TITLE
Refactor `view_config_val_errors()`

### DIFF
--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -1,8 +1,23 @@
+#' Create a schema or instance path locating a config validation error
+#'
+#' @param schema list representation of a schema object or property containing the
+#' property the error is located in.
+#' @param element character string. The name of the property to create a path to.
+#' @param type character string. Path type. One of "schema" or "instance".
+#' @param append_item_n Logical. Whether to append an items index for the contents
+#' of an array property (`TRUE`) or just create a path to the property itself
+#' (`FALSE` default).
+#'
+#'
+#' @return a path, either to an instance location in the config or a location in
+#' the schema.
+#' @noRd
 get_error_path <- function(schema, element = "target_metadata",
                            type = c("schema", "instance"),
                            append_item_n = FALSE) {
   type <- rlang::arg_match(type)
 
+  # Create a character vector of schema paths
   schema_paths <- schema %>%
     jsonlite::fromJSON(simplifyDataFrame = FALSE) %>%
     unlist(recursive = TRUE, use.names = TRUE) %>%
@@ -10,6 +25,7 @@ get_error_path <- function(schema, element = "target_metadata",
     gsub("\\.", "/", .) %>%
     paste0("/", .)
 
+  # Subset to the schema paths to the element in question
   path <- grep(paste0(".*", element, "/type([0-9])?$"),
     schema_paths,
     value = TRUE
@@ -17,8 +33,8 @@ get_error_path <- function(schema, element = "target_metadata",
     gsub("/type([0-9])?", "", .) %>%
     unique()
 
-  # Instance paths to custom task IDs can be created by appending the element
-  # name to the task ID properties.
+  # Instance paths to custom task IDs (which will not have been matche in the schema)
+  # can be created by appending the element name to the task ID properties path.
   if (length(path) == 0L && type == "instance") {
     path <- grep(paste0(".*", "task_ids", "/type([0-9])?$"),
       schema_paths,
@@ -29,9 +45,10 @@ get_error_path <- function(schema, element = "target_metadata",
       paste("properties", element, sep = "/")
   }
 
-  # Schema paths to custom task IDs can be created by pointing to the task_ids
-  # additionalProperties schema.
-  # This will only retrun a path with schema v2.0.0 and above, when
+  # Schema paths to custom task IDs can be created by sub-setting the task_ids
+  # additionalProperties schema (which is a stand-in for custom task IDs in the
+  # schema).
+  # This will only return a path with schema v2.0.0 and above, when
   # additionalProperties became an object.
   if (length(path) == 0L && type == "schema") {
     path <- grep(".*task_ids/additionalProperties/type([0-9])?$",

--- a/R/view_config_val_errors.R
+++ b/R/view_config_val_errors.R
@@ -173,7 +173,7 @@ dataframe_to_markdown <- function(x) {
     gsub("[^']NA", "'NA'", .)
 }
 
-# Collapse individual cell entries to a single string according to their type. 
+# Collapse individual cell entries to a single string according to their type.
 # - data.frames are processed with markdown formatting
 # - vectors are collapsed to a comma-separated string
 collapse_element <- function(x) {

--- a/R/view_config_val_errors.R
+++ b/R/view_config_val_errors.R
@@ -234,8 +234,10 @@ remove_superfluous_enum_rows <- function(errors_tbl) {
 }
 
 # Extract informative values from params data.frame and add it to the data column
-extract_params_to_data <- function(errors_tbl, param = c(
-                                     "additionalProperties", "required"
+extract_params_to_data <- function(errors_tbl,
+                                   param = c(
+                                     "additionalProperties",
+                                     "required"
                                    )) {
   param <- rlang::arg_match(param)
   which <- errors_tbl$keyword == param

--- a/R/view_config_val_errors.R
+++ b/R/view_config_val_errors.R
@@ -173,8 +173,9 @@ dataframe_to_markdown <- function(x) {
     gsub("[^']NA", "'NA'", .)
 }
 
-# Collapse individual cell entries according to their type. Data.frames are processed
-# with markdown formatting to strings and vectors are collapsed into a single string.
+# Collapse individual cell entries to a single string according to their type. 
+# - data.frames are processed with markdown formatting
+# - vectors are collapsed to a comma-separated string
 collapse_element <- function(x) {
   if (inherits(x, "data.frame")) {
     return(dataframe_to_markdown(x))

--- a/R/view_config_val_errors.R
+++ b/R/view_config_val_errors.R
@@ -24,18 +24,24 @@ view_config_val_errors <- function(x) {
     ))
     return(invisible(NULL))
   }
+  error_df <- summarise_errors(x)
+  render_errors_df(error_df)
+}
 
+# Compile, clean and process validations errors attribute(s) into errors_df
+# ready for rendering. Attach necessary metadata as attributes.
+summarise_errors <- function(x) {
   if (length(x) > 1L) {
     # Process multiple config file error_tbls
     error_df <- purrr::map2(
       x, names(x),
       ~ compile_errors(.x, .y) %>%
-        process_error_df()
+        clean_error_df()
     ) %>%
       purrr::list_rbind()
-    val_path <- attr(x, "config_dir")
-    val_type <- "directory"
-    error_loc_columns <- c(
+    attr(error_df, "path") <- attr(x, "config_dir")
+    attr(error_df, "type") <- "directory"
+    attr(error_df, "loc_cols") <- c(
       "fileName",
       "instancePath",
       "schemaPath"
@@ -43,23 +49,233 @@ view_config_val_errors <- function(x) {
   } else {
     # Process single config file error_tbl
     error_df <- attr(x, "errors") %>%
-      process_error_df()
-    val_path <- attr(x, "config_path")
-    val_type <- "file"
-    error_loc_columns <- c(
+      clean_error_df()
+    attr(error_df, "path") <- attr(x, "config_path")
+    attr(error_df, "type") <- "file"
+    attr(error_df, "loc_cols") <- c(
       "instancePath",
       "schemaPath"
     )
   }
+  attr(error_df, "schema_version") <- attr(x, "schema_version")
+  attr(error_df, "schema_url") <- attr(x, "schema_url")
 
-  schema_version <- attr(x, "schema_version")
-  schema_url <- attr(x, "schema_url")
+  error_df
+}
+
+# Compile errors from multiple config files into a single data.frame
+compile_errors <- function(x, file_name) {
+  errors_tbl <- attr(x, "errors")
+  if (!is.null(errors_tbl)) {
+    cbind(
+      fileName = rep(fs::path(file_name, ext = "json"), nrow(errors_tbl)),
+      errors_tbl
+    )
+  }
+}
+
+# Overall error_df processing to remove superfluous columns, extract pertinent
+# information into more standard columns and formats.
+clean_error_df <- function(errors_tbl) {
+  if (is.null(errors_tbl)) {
+    return(NULL)
+  }
+  errors_tbl[c("dataPath", "parentSchema")] <- NULL
+  errors_tbl <- errors_tbl[!grepl("oneOf.+", errors_tbl$schemaPath), ]
+  errors_tbl <- remove_superfluous_enum_rows(errors_tbl)
+
+  # Get rid of unnecessarily verbose data entry when a data column is a data.frame
+  if (inherits(errors_tbl$data, "data.frame")) {
+    errors_tbl$data <- ""
+  }
+
+  # Extract missingProperties property names from params to the data column.
+  if (any(errors_tbl$keyword == "required")) {
+    errors_tbl <- extract_params_to_data(errors_tbl, "required")
+  }
+
+  # Extract additionalProperties property names to the data column.
+  if (any(errors_tbl$keyword == "additionalProperties")) {
+    errors_tbl <- extract_params_to_data(errors_tbl, "additionalProperties")
+  }
+
+  # Remove params column
+  errors_tbl["params"] <- NULL
+
+  error_df <- split(errors_tbl, seq_len(nrow(errors_tbl))) %>%
+    purrr::map(
+      ~ unlist(.x, recursive = FALSE) %>%
+        purrr::map(~ collapse_element(.x)) %>%
+        tibble::as_tibble()
+    ) %>%
+    purrr::list_rbind() %>%
+    # split long column names
+    stats::setNames(gsub("\\.", " ", names(.)))
+
+  error_df
+}
+
+# Create tree representation of error (instance and schema) paths
+path_to_tree <- function(x) {
+  # Split up path and remove blank and root elements
+  paths <- strsplit(x, "/") %>%
+    unlist() %>%
+    as.list()
+  paths <- paths[!(paths == "" | paths == "#")]
+
+  # Highlight property names and convert from 0 to 1 array index
+  paths <- paths %>%
+    purrr::map_if(
+      !is.na(as.numeric(paths)),
+      ~ as.numeric(.x) + 1
+    ) %>%
+    purrr::map_if(
+      !paths %in% c("items", "properties"),
+      ~ paste0("**", .x, "**")
+    ) %>%
+    unlist() %>%
+    suppressWarnings()
+
+  # build path tree
+  if (length(paths) > 1L) {
+    for (i in 2:length(paths)) {
+      paths[i] <- paste0(
+        "\u2514",
+        paste(rep("\u2500", times = i - 2),
+          collapse = ""
+        ),
+        paths[i]
+      )
+    }
+  }
+  paste(paths, collapse = " \n ")
+}
+
+# Process and mark up data.frame cell entries (e.g. a `properties` df) with
+# markdown formatting and collapse to a single string. Mainly applicable to
+# oneOf schema column cell formatting.
+dataframe_to_markdown <- function(x) {
+  # Process data.frame row by row
+  split(x, seq_len(nrow(x))) %>%
+    purrr::map(
+      ~ unlist(.x, use.names = TRUE) %>%
+        stats::setNames(gsub("properties\\.", "", names(.))) %>%
+        stats::setNames(gsub("\\.", "-", names(.))) %>%
+        remove_null_properties() %>%
+        paste0("**", names(.), ":** ", .) %>%
+        paste(collapse = " \n ")
+    ) %>%
+    unlist(use.names = TRUE) %>%
+    paste0("**", names(.), "** \n ", .) %>%
+    paste(collapse = "\n\n ") %>%
+    gsub("[^']NA", "'NA'", .)
+}
+
+# Collapse individual cell entries according to their type. Data.frames are processed
+# with markdown formatting to strings and vectors are collapsed into a single string.
+collapse_element <- function(x) {
+  if (inherits(x, "data.frame")) {
+    return(dataframe_to_markdown(x))
+  }
+  vector_to_character(x)
+}
+
+# Process vector error tbl cell entries into a single string
+vector_to_character <- function(x) {
+  # unlist and collapse list columns
+  out <- unlist(x, recursive = TRUE, use.names = TRUE)
+
+  if (length(names(out)) != 0L) {
+    out <- paste0(names(out), ": ", out)
+  }
+  out %>% paste(collapse = ", ")
+}
+
+# In oneOf validation of point estimate output type IDs,
+# the maxItems and matching const property of one of the properties is not
+# informative and can be removed. Only relevant to pre v4.0.0 schema versions
+remove_null_properties <- function(x) {
+  null_maxitem <- names(x[is.na(x) & grepl("maxItems", names(x))])
+  x[!names(x) %in% c(
+    null_maxitem,
+    gsub(
+      "maxItems", "const",
+      null_maxitem
+    )
+  )]
+}
+
+# Remove rows with duplicate instancePath values that are not informative. This affects
+# enum schema deviations in particular
+remove_superfluous_enum_rows <- function(errors_tbl) {
+  dup_inst <- duplicated(errors_tbl$instancePath)
+
+  if (any(dup_inst)) {
+    dup_idx <- errors_tbl$instancePath[dup_inst] %>%
+      purrr::map(~ which(errors_tbl$instancePath == .x))
+
+    dup_keywords <- purrr::map(dup_idx, ~ errors_tbl$keyword[.x])
+
+    dup_unneccessary <- purrr::map_lgl(
+      dup_keywords,
+      ~ all(.x == c("type", "enum") | .x == c("type", "const"))
+    )
+
+    if (any(dup_unneccessary)) {
+      remove_idx <- purrr::map_int(
+        dup_idx[dup_unneccessary],
+        ~ .x[2]
+      )
+      errors_tbl <- errors_tbl[-remove_idx, ]
+    }
+  }
+
+  errors_tbl
+}
+
+# Extract informative values from params data.frame and add it to the data column
+extract_params_to_data <- function(errors_tbl, param = c(
+                                     "additionalProperties", "required"
+                                   )) {
+  param <- rlang::arg_match(param)
+  which <- errors_tbl$keyword == param
+
+  # If a params object is missing, replace data column with empty string as
+  # the contents are too verbose to be informative and return early
+  if (is.null(errors_tbl$params)) {
+    errors_tbl$data[which] <- ""
+    return(errors_tbl)
+  }
+  # Get names of missing/additional properties from params object
+  at <- switch(param,
+    required = "missingProperty",
+    additionalProperties = "additionalProperty"
+  )
+  data_vals <- purrr::keep_at(errors_tbl$params, at) |> unlist()
+
+  # Replace appropriate rows in data column with property names
+  errors_tbl$data[which] <- data_vals[which]
+  errors_tbl
+}
+
+render_errors_df <- function(error_df) {
+  schema_version <- attr(error_df, "schema_version")
+  schema_url <- attr(error_df, "schema_url")
+  path <- attr(error_df, "path")
+  type <- attr(error_df, "type")
+  loc_cols <- attr(error_df, "loc_cols")
 
   title <- gt::md("**`hubAdmin` config validation error report**")
   subtitle <- gt::md(
-    glue::glue("Report for {val_type} **`{val_path}`** using
+    glue::glue("Report for {type} **`{path}`** using
                    schema version [**{schema_version}**]({schema_url})")
   )
+
+  # format path and error message columns
+  error_df[["schemaPath"]] <- purrr::map_chr(error_df[["schemaPath"]], path_to_tree)
+  error_df[["instancePath"]] <- purrr::map_chr(error_df[["instancePath"]], path_to_tree)
+  error_df[["message"]] <- paste("\u274c", error_df[["message"]])
+
 
   # Create table ----
   gt::gt(error_df) %>%
@@ -69,7 +285,7 @@ view_config_val_errors <- function(x) {
     ) %>%
     gt::tab_spanner(
       label = gt::md("**Error location**"),
-      columns = error_loc_columns
+      columns = loc_cols
     ) %>%
     gt::tab_spanner(
       label = gt::md("**Schema details**"),
@@ -134,205 +350,4 @@ view_config_val_errors <- function(x) {
       source_note = gt::md("For more information, please consult the
                                  [**`hubDocs` documentation**.](https://hubverse.io/en/latest/)")
     )
-}
-
-# Create tree representation of error (instance and schema) paths
-path_to_tree <- function(x) {
-  # Split up path and remove blank and root elements
-  paths <- strsplit(x, "/") %>%
-    unlist() %>%
-    as.list()
-  paths <- paths[!(paths == "" | paths == "#")]
-
-  # Highlight property names and convert from 0 to 1 array index
-  paths <- paths %>%
-    purrr::map_if(
-      !is.na(as.numeric(paths)),
-      ~ as.numeric(.x) + 1
-    ) %>%
-    purrr::map_if(
-      !paths %in% c("items", "properties"),
-      ~ paste0("**", .x, "**")
-    ) %>%
-    unlist() %>%
-    suppressWarnings()
-
-  # build path tree
-  if (length(paths) > 1L) {
-    for (i in 2:length(paths)) {
-      paths[i] <- paste0(
-        "\u2514",
-        paste(rep("\u2500", times = i - 2),
-          collapse = ""
-        ),
-        paths[i]
-      )
-    }
-  }
-  paste(paths, collapse = " \n ")
-}
-
-# Process and mark up data.frame cell entries (e.g. a `properties` df) with
-# markdown formatting and collapse to a single string. Mainly applicable to
-# oneOf schema column cell formatting.
-dataframe_to_markdown <- function(x) {
-  # Process data.frame row by row
-  split(x, seq_len(nrow(x))) %>%
-    purrr::map(
-      ~ unlist(.x, use.names = TRUE) %>%
-        stats::setNames(gsub("properties\\.", "", names(.))) %>%
-        stats::setNames(gsub("\\.", "-", names(.))) %>%
-        remove_null_properties() %>%
-        paste0("**", names(.), ":** ", .) %>%
-        paste(collapse = " \n ")
-    ) %>%
-    unlist(use.names = TRUE) %>%
-    paste0("**", names(.), "** \n ", .) %>%
-    paste(collapse = "\n\n ") %>%
-    gsub("[^']NA", "'NA'", .)
-}
-
-# precess individual cell entries according to their type. Data.frames are processed
-# with markdown formatting to strings and vectors are collapsed into a single string.
-process_element <- function(x) {
-  if (inherits(x, "data.frame")) {
-    return(dataframe_to_markdown(x))
-  }
-  vector_to_character(x)
-}
-
-# Process vector error tbl cell entries into a single string
-vector_to_character <- function(x) {
-  # unlist and collapse list columns
-  out <- unlist(x, recursive = TRUE, use.names = TRUE)
-
-  if (length(names(out)) != 0L) {
-    out <- paste0(names(out), ": ", out)
-  }
-  out %>% paste(collapse = ", ")
-}
-
-# In oneOf validation of point estimate output type IDs,
-# the maxItems and matching const property of one of the properties is not
-# informative and can be removed. Only relevant to pre v4.0.0 schema versions
-remove_null_properties <- function(x) {
-  null_maxitem <- names(x[is.na(x) & grepl("maxItems", names(x))])
-  x[!names(x) %in% c(
-    null_maxitem,
-    gsub(
-      "maxItems", "const",
-      null_maxitem
-    )
-  )]
-}
-
-# Remove rows with duplicate instancePath values that are not informative. This affects
-# enum schema deviations in particular
-remove_superfluous_enum_rows <- function(errors_tbl) {
-  dup_inst <- duplicated(errors_tbl$instancePath)
-
-  if (any(dup_inst)) {
-    dup_idx <- errors_tbl$instancePath[dup_inst] %>%
-      purrr::map(~ which(errors_tbl$instancePath == .x))
-
-    dup_keywords <- purrr::map(dup_idx, ~ errors_tbl$keyword[.x])
-
-    dup_unneccessary <- purrr::map_lgl(
-      dup_keywords,
-      ~ all(.x == c("type", "enum") | .x == c("type", "const"))
-    )
-
-    if (any(dup_unneccessary)) {
-      remove_idx <- purrr::map_int(
-        dup_idx[dup_unneccessary],
-        ~ .x[2]
-      )
-      errors_tbl <- errors_tbl[-remove_idx, ]
-    }
-  }
-
-  errors_tbl
-}
-
-# Compile errors from multiple config files into a single data.frame
-compile_errors <- function(x, file_name) {
-  errors_tbl <- attr(x, "errors")
-  if (!is.null(errors_tbl)) {
-    cbind(
-      fileName = rep(fs::path(file_name, ext = "json"), nrow(errors_tbl)),
-      errors_tbl
-    )
-  }
-}
-
-# Overall error_df processing to remove superfluous columns, extract pertinent
-# information into more standard columns and formats.
-process_error_df <- function(errors_tbl) {
-  if (is.null(errors_tbl)) {
-    return(NULL)
-  }
-  errors_tbl[c("dataPath", "parentSchema")] <- NULL
-  errors_tbl <- errors_tbl[!grepl("oneOf.+", errors_tbl$schemaPath), ]
-  errors_tbl <- remove_superfluous_enum_rows(errors_tbl)
-
-  # Get rid of unnecessarily verbose data entry when a data column is a data.frame
-  if (inherits(errors_tbl$data, "data.frame")) {
-    errors_tbl$data <- ""
-  }
-
-  # Extract missingProperties property names from params to the data column.
-  if (any(errors_tbl$keyword == "required")) {
-    errors_tbl <- extract_params_to_data(errors_tbl, "required")
-  }
-
-  # Extract additionalProperties property names to the data column.
-  if (any(errors_tbl$keyword == "additionalProperties")) {
-    errors_tbl <- extract_params_to_data(errors_tbl, "additionalProperties")
-  }
-
-  # Remove params column
-  errors_tbl["params"] <- NULL
-
-  error_df <- split(errors_tbl, seq_len(nrow(errors_tbl))) %>%
-    purrr::map(
-      ~ unlist(.x, recursive = FALSE) %>%
-        purrr::map(~ process_element(.x)) %>%
-        tibble::as_tibble()
-    ) %>%
-    purrr::list_rbind() %>%
-    # split long column names
-    stats::setNames(gsub("\\.", " ", names(.)))
-
-
-  # format path and error message columns
-  error_df[["schemaPath"]] <- purrr::map_chr(error_df[["schemaPath"]], path_to_tree)
-  error_df[["instancePath"]] <- purrr::map_chr(error_df[["instancePath"]], path_to_tree)
-  error_df[["message"]] <- paste("\u274c", error_df[["message"]])
-
-  error_df
-}
-
-# Extract informative values from params data.frame and add it to the data column
-extract_params_to_data <- function(errors_tbl, param = c(
-                                     "additionalProperties", "required"
-                                   )) {
-  param <- rlang::arg_match(param)
-  which <- errors_tbl$keyword == param
-
-  # If a params object is missing, replace data column with empty string as
-  # the contents are too verbose to be informative and return early
-  if (is.null(errors_tbl$params)) {
-    errors_tbl$data[which] <- ""
-    return(errors_tbl)
-  }
-  # Get names of missing/additional properties from params object
-  at <- switch(param,
-    required = "missingProperty",
-    additionalProperties = "additionalProperty"
-  )
-  data_vals <- purrr::keep_at(errors_tbl$params, at) |> unlist()
-
-  # Replace appropriate rows in data column with property names
-  errors_tbl$data[which] <- data_vals[which]
-  errors_tbl
 }

--- a/R/view_config_val_errors.R
+++ b/R/view_config_val_errors.R
@@ -103,16 +103,18 @@ clean_error_df <- function(errors_tbl) {
   errors_tbl["params"] <- NULL
 
   error_df <- split(errors_tbl, seq_len(nrow(errors_tbl))) %>%
-    purrr::map(
-      ~ unlist(.x, recursive = FALSE) %>%
-        purrr::map(~ collapse_element(.x)) %>%
-        tibble::as_tibble()
-    ) %>%
+    purrr::map(~ flatten_error_tbl_row(.x)) %>%
     purrr::list_rbind() %>%
     # split long column names
     stats::setNames(gsub("\\.", " ", names(.)))
 
   error_df
+}
+
+flatten_error_tbl_row <- function(x) {
+  unlist(x, recursive = FALSE) %>%
+    purrr::map(~ collapse_element(.x)) %>%
+    tibble::as_tibble()
 }
 
 # Create tree representation of error (instance and schema) paths

--- a/tests/testthat/_snaps/view_config_val_errors.md
+++ b/tests/testthat/_snaps/view_config_val_errors.md
@@ -40,6 +40,11 @@
        $ message     : chr [1:3] "❌ must be array,null" "❌ must match exactly one schema in oneOf" "❌ must match exactly one schema in oneOf"
        $ schema      : chr [1:3] "array, null" "**1** \n **required-description:** When mean is required, property set to single element 'NA' array \n **requir"| __truncated__ "**1** \n **relative_to-description:** Name of task id variable in relation to which submission start and end da"| __truncated__
        $ data        : chr [1:3] "wk inc flu hosp" "required: NA, optional: NA" "start: -6, end: 1"
+       - attr(*, "path")= chr "testdata/tasks-errors.json"
+       - attr(*, "type")= chr "file"
+       - attr(*, "loc_cols")= chr [1:2] "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v0.0.0.9"
+       - attr(*, "schema_url")= 'glue' chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v0.0.0.9/tasks-schema.json"
 
 ---
 
@@ -78,6 +83,11 @@
        $ message     : chr [1:2] "❌ must be equal to one of the allowed values" "❌ must be string"
        $ schema      : chr [1:2] "csv, parquet, arrow" "string"
        $ data        : chr [1:2] "csvs" "US/Eastern"
+       - attr(*, "path")= chr "testdata/admin-errors2.json"
+       - attr(*, "type")= chr "file"
+       - attr(*, "loc_cols")= chr [1:2] "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v1.0.0"
+       - attr(*, "schema_url")= 'glue' chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v1.0.0/admin-schema.json"
 
 # Data column handled correctly when required property missing
 
@@ -91,6 +101,11 @@
        $ message     : chr [1:2] "❌ must have required property 'target_metadata'" "❌ must be number,integer"
        $ schema      : chr [1:2] "task_ids, output_type, target_metadata" "number, integer"
        $ data        : chr [1:2] "target_metadata" "0"
+       - attr(*, "path")= chr "testdata/tasks_required_missing.json"
+       - attr(*, "type")= chr "file"
+       - attr(*, "loc_cols")= chr [1:2] "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v2.0.0"
+       - attr(*, "schema_url")= 'glue' chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
 
 ---
 
@@ -104,6 +119,11 @@
        $ message     : chr "❌ must have required property 'target_metadata'"
        $ schema      : chr "task_ids, output_type, target_metadata"
        $ data        : chr "target_metadata"
+       - attr(*, "path")= chr "testdata/tasks_required_missing_only.json"
+       - attr(*, "type")= chr "file"
+       - attr(*, "loc_cols")= chr [1:2] "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v2.0.0"
+       - attr(*, "schema_url")= 'glue' chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
 
 ---
 
@@ -117,6 +137,11 @@
        $ message     : chr [1:2] "❌ must have required property 'round_id_from_variable'" "❌ must have required property 'target_metadata'"
        $ schema      : chr [1:2] "round_id_from_variable, round_id, model_tasks, submissions_due" "task_ids, output_type, target_metadata"
        $ data        : chr [1:2] "round_id_from_variable" "target_metadata"
+       - attr(*, "path")= chr "testdata/tasks_required_missing_only2.json"
+       - attr(*, "type")= chr "file"
+       - attr(*, "loc_cols")= chr [1:2] "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v2.0.0"
+       - attr(*, "schema_url")= 'glue' chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
 
 ---
 
@@ -130,6 +155,11 @@
        $ message     : chr [1:2] "❌ must have required property 'output_type'" "❌ must have required property 'target_metadata'"
        $ schema      : chr [1:2] "task_ids, output_type, target_metadata" "task_ids, output_type, target_metadata"
        $ data        : chr [1:2] "output_type" "target_metadata"
+       - attr(*, "path")= chr "testdata/tasks_required_missing_only2b.json"
+       - attr(*, "type")= chr "file"
+       - attr(*, "loc_cols")= chr [1:2] "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v2.0.0"
+       - attr(*, "schema_url")= 'glue' chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
 
 # Report handles additional property errors successfully
 
@@ -143,6 +173,11 @@
        $ message     : chr "❌ must NOT have additional properties"
        $ schema      : chr "FALSE"
        $ data        : chr "target_metadata"
+       - attr(*, "path")= chr "testdata/tasks-addprop.json"
+       - attr(*, "type")= chr "file"
+       - attr(*, "loc_cols")= chr [1:2] "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v2.0.0"
+       - attr(*, "schema_url")= 'glue' chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
 
 # Report works corectly on validate_hub_config output
 
@@ -157,4 +192,9 @@
        $ message     : chr [1:5] "❌ must have required property 'target_metadata'" "❌ must be array,null" "❌ must match exactly one schema in oneOf" "❌ must match exactly one schema in oneOf" ...
        $ schema      : chr [1:5] "task_ids, output_type, target_metadata" "array, null" "**1** \n **required-description:** When mean is required, property set to single element 'NA' array \n **requir"| __truncated__ "**1** \n **relative_to-description:** Name of task id variable in relation to which submission start and end da"| __truncated__ ...
        $ data        : chr [1:5] "target_metadata" "wk inc flu hosp" "required: NA, optional: NA" "start: -6, end: 1" ...
+       - attr(*, "path")= 'fs_path' chr "testdata/error_hub/hub-config"
+       - attr(*, "type")= chr "directory"
+       - attr(*, "loc_cols")= chr [1:3] "fileName" "instancePath" "schemaPath"
+       - attr(*, "schema_version")= chr "v2.0.0"
+       - attr(*, "schema_url")= chr "https://github.com/hubverse-org/schemas/tree/main/v2.0.0"
 

--- a/tests/testthat/_snaps/view_config_val_errors.md
+++ b/tests/testthat/_snaps/view_config_val_errors.md
@@ -90,7 +90,7 @@
        $ keyword     : chr [1:2] "required" "type"
        $ message     : chr [1:2] "❌ must have required property 'target_metadata'" "❌ must be number,integer"
        $ schema      : chr [1:2] "task_ids, output_type, target_metadata" "number, integer"
-       $ data        : chr [1:2] "" "0"
+       $ data        : chr [1:2] "target_metadata" "0"
 
 ---
 
@@ -103,7 +103,7 @@
        $ keyword     : chr "required"
        $ message     : chr "❌ must have required property 'target_metadata'"
        $ schema      : chr "task_ids, output_type, target_metadata"
-       $ data        : chr ""
+       $ data        : chr "target_metadata"
 
 ---
 
@@ -116,7 +116,7 @@
        $ keyword     : chr [1:2] "required" "required"
        $ message     : chr [1:2] "❌ must have required property 'round_id_from_variable'" "❌ must have required property 'target_metadata'"
        $ schema      : chr [1:2] "round_id_from_variable, round_id, model_tasks, submissions_due" "task_ids, output_type, target_metadata"
-       $ data        : chr [1:2] "" ""
+       $ data        : chr [1:2] "round_id_from_variable" "target_metadata"
 
 ---
 
@@ -129,7 +129,7 @@
        $ keyword     : chr [1:2] "required" "required"
        $ message     : chr [1:2] "❌ must have required property 'output_type'" "❌ must have required property 'target_metadata'"
        $ schema      : chr [1:2] "task_ids, output_type, target_metadata" "task_ids, output_type, target_metadata"
-       $ data        : chr [1:2] "" ""
+       $ data        : chr [1:2] "output_type" "target_metadata"
 
 # Report handles additional property errors successfully
 
@@ -142,7 +142,7 @@
        $ keyword     : chr "additionalProperties"
        $ message     : chr "❌ must NOT have additional properties"
        $ schema      : chr "FALSE"
-       $ data        : chr ""
+       $ data        : chr "target_metadata"
 
 # Report works corectly on validate_hub_config output
 
@@ -156,5 +156,5 @@
        $ keyword     : chr [1:5] "required" "type" "oneOf" "oneOf" ...
        $ message     : chr [1:5] "❌ must have required property 'target_metadata'" "❌ must be array,null" "❌ must match exactly one schema in oneOf" "❌ must match exactly one schema in oneOf" ...
        $ schema      : chr [1:5] "task_ids, output_type, target_metadata" "array, null" "**1** \n **required-description:** When mean is required, property set to single element 'NA' array \n **requir"| __truncated__ "**1** \n **relative_to-description:** Name of task id variable in relation to which submission start and end da"| __truncated__ ...
-       $ data        : chr [1:5] "" "wk inc flu hosp" "required: NA, optional: NA" "start: -6, end: 1" ...
+       $ data        : chr [1:5] "target_metadata" "wk inc flu hosp" "required: NA, optional: NA" "start: -6, end: 1" ...
 


### PR DESCRIPTION
While working on validating v4 schema, it made sense to:
- Make the output of `view_config_val_errors()` more informative when additional properties are present but not allowed by extracting the name of additional properties into the `data` column.
- Refactor the main function into more modular functions and add comments to clarify what's going on