### PR TITLE
Add v4 dynamic validation checks and tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # hubAdmin (development version)
 
 * Support v4.0.0 schema configuration of output types and output type IDs when creating config files programmatically. Specifically, whether an output type is required or not is specified via the `is_required` logical property whereas the `output_type_id` values as provided through the `required` property.
+* Add dynamic checks to ensure `derived_task_ids` match valid task ID names to validation of `task.json` config files (#69).
 
 # hubAdmin 1.3.0
 

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -2,7 +2,10 @@
 #'
 #' @param schema list representation of a schema object or property containing the
 #' property the error is located in.
-#' @param element character string. The name of the property to create a path to.
+#' @param element character string. The name of or partial path to the property
+#' to create a path to. If there are multiple paths matching the property name,
+#' the path at the highest depth is returned. To target properties at a specific depth
+#' use a longer part of the path instead of just the property name.
 #' @param type character string. Path type. One of "schema" or "instance".
 #' @param append_item_n Logical. Whether to append an items index for the contents
 #' of an array property (`TRUE`) or just create a path to the property itself
@@ -10,8 +13,27 @@
 #'
 #'
 #' @return a path, either to an instance location in the config or a location in
-#' the schema.
+#' the schema. Note that in instance paths. any array location indices are
+#' unevaluated in the output and are instead encoded a glue interpolation strings
+#' (i.e wrapped in `{}`).
+#' They are defined by variables `round_i`, `model_task_i` or `target_key_i` depending
+#' on the depth of the property being validated. Values for these variables need to be passed
+#' using `glue::glue_data()` and explicitly.
+#' passing an index variable and it's value as a named list.
 #' @noRd
+#' @examples
+#' # Return the instance path to the origin date task ID in the second modeling task
+#' # (overriding the `model_task_i` value in the caller environment)
+#' model_task_i <- 1L
+#' round_i <- 2L
+#' glue::glue_data(
+#'   list(model_task_i = 2L),
+#'   get_error_path(schema, "origin_date", "instance")
+#' )
+#' # By default, firsth highest level match returned
+#' get_error_path(schema, "derived_task_ids", "schema")
+#' # Target lower level properties by defining more of the path
+#' get_error_path(schema, "rounds/items/properties/derived_task_ids", "schema")
 get_error_path <- function(schema, element = "target_metadata",
                            type = c("schema", "instance"),
                            append_item_n = FALSE) {
@@ -25,15 +47,21 @@ get_error_path <- function(schema, element = "target_metadata",
     gsub("\\.", "/", .) %>%
     paste0("/", .)
 
-  # Subset to the schema paths to the element in question
+  # Subset to the schema paths to the element in question. By sub-setting to the `type[0-9]`
+  # path associated with a property, we ensure we limit to a leaf path (not
+  #  deeper paths in the schema that include the property of interest as a parent).
   path <- grep(paste0(".*", element, "/type([0-9])?$"),
     schema_paths,
     value = TRUE
   ) %>%
+    # here we remove the unnecessary `type[0-9]` part of the path we used to ensure
+    # a leaf path.
     gsub("/type([0-9])?", "", .) %>%
-    unique()
+    unique() |>
+    detect_first()
 
-  # Instance paths to custom task IDs (which will not have been matche in the schema)
+
+  # Instance paths to custom task IDs (which will not have been matched in the schema)
   # can be created by appending the element name to the task ID properties path.
   if (length(path) == 0L && type == "instance") {
     path <- grep(paste0(".*", "task_ids", "/type([0-9])?$"),
@@ -59,6 +87,11 @@ get_error_path <- function(schema, element = "target_metadata",
       unique()
   }
 
+  # If the path we are targeting is an an array (i.e. property name is followed
+  # by "items" and `append_item_n` is `TRUE`, (i.e. we want to include the
+  # index to a specific element in that object), then add an "\items" string to the
+  # end of the path where a location index will be added during instance
+  # path interpolation.
   if (append_item_n && any(
     grepl(
       paste(path, "items", sep = "/"),
@@ -70,23 +103,35 @@ get_error_path <- function(schema, element = "target_metadata",
     path <- paste(path, "items", sep = "/")
   }
 
-
   switch(type,
     schema = if (length(path) == 0L) NA else paste0("#", path),
     instance = generate_instance_path_glue(path)
   )
 }
 
+# To create instance path, remove `properties/` elements and substitute `items`
+# elements with error position index glue interpolation expression. to be evaluated
+# later via glue::glue_data().
 generate_instance_path_glue <- function(path) {
-  split_path <- gsub("properties/", "", path) %>%
-    strsplit("/") %>%
-    unlist()
-
-  is_item <- split_path == "items"
-  split_path[is_item] <- c(
+  item_props <- c(
     "{round_i - 1}",
     "{model_task_i - 1}",
     "{target_key_i - 1}"
-  )[1:sum(is_item)]
+  )
+  split_path <- gsub("properties/", "", path) %>%
+    strsplit("/") %>%
+    unlist()
+  is_item <- split_path == "items"
+  n_item_props <- sum(is_item)
+  split_path[is_item] <- utils::head(item_props, n_item_props)
   paste(split_path, collapse = "/")
+}
+
+# Find the first path in a vector of paths by depth (ordered by order of depth -
+# deepest last)
+detect_first <- function(paths) {
+  min_idx <- stringr::str_split(paths, "/") |>
+    lengths() |>
+    which.min()
+  paths[min_idx]
 }

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -92,14 +92,9 @@ get_error_path <- function(schema, element = "target_metadata",
   # index to a specific element in that object), then add an "\items" string to the
   # end of the path where a location index will be added during instance
   # path interpolation.
-  if (append_item_n && any(
-    grepl(
-      paste(path, "items", sep = "/"),
-      schema_paths
-    )
-  ) &&
-    length(path) != 0L
-  ) {
+  path_exists <- length(path) != 0
+  is_array <- any(grepl(paste(path, "items", sep = "/"), schema_paths))
+  if (append_item_n && path_exists && is_array) {
     path <- paste(path, "items", sep = "/")
   }
 

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -13,7 +13,7 @@
 #'
 #'
 #' @return a path, either to an instance location in the config or a location in
-#' the schema. Note that in instance paths. any array location indices are
+#' the schema. Note that in instance paths, any array location indices are
 #' unevaluated in the output and are instead encoded a glue interpolation strings
 #' (i.e wrapped in `{}`).
 #' They are defined by variables `round_i`, `model_task_i` or `target_key_i` depending

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -118,7 +118,7 @@ generate_instance_path_glue <- function(path) {
     unlist()
   is_item <- split_path == "items"
   n_item_props <- sum(is_item)
-  split_path[is_item] <- utils::head(item_props, n_item_props)
+  split_path[is_item] <- item_props[seq_len(n_item_props)]
   paste(split_path, collapse = "/")
 }
 

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -30,7 +30,7 @@
 #'   list(model_task_i = 2L),
 #'   get_error_path(schema, "origin_date", "instance")
 #' )
-#' # By default, firsth highest level match returned
+#' # By default, first highest level match returned
 #' get_error_path(schema, "derived_task_ids", "schema")
 #' # Target lower level properties by defining more of the path
 #' get_error_path(schema, "rounds/items/properties/derived_task_ids", "schema")

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -18,8 +18,8 @@
 #' (i.e wrapped in `{}`).
 #' They are defined by variables `round_i`, `model_task_i` or `target_key_i` depending
 #' on the depth of the property being validated. Values for these variables need to be passed
-#' using `glue::glue_data()` and explicitly.
-#' passing an index variable and it's value as a named list.
+#' using `glue::glue_data()` and explicitly passing an index variable
+#' and it's value as a named list.
 #' @noRd
 #' @examples
 #' # Return the instance path to the origin date task ID in the second modeling task

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -159,7 +159,8 @@ perform_dynamic_config_validations <- function(validation) {
     # Perform config level validation
     list(
       validate_round_ids_unique(config_json, schema),
-      validate_task_ids_not_all_null(config_json, schema)
+      validate_task_ids_not_all_null(config_json, schema),
+      validate_config_derived_task_ids(config_json, schema)
     )
   ) %>%
     purrr::list_rbind()
@@ -230,6 +231,11 @@ val_round <- function(round, round_i, schema) {
     ),
     list(
       validate_round_ids_consistent(
+        round = round,
+        round_i = round_i,
+        schema = schema
+      ),
+      validate_round_derived_task_ids(
         round = round,
         round_i = round_i,
         schema = schema

--- a/tests/testthat/_snaps/validate_config.md
+++ b/tests/testthat/_snaps/validate_config.md
@@ -979,3 +979,29 @@
                                                       dataPath
       1 /rounds/0/model_tasks/0/output_type/pmf/output_type_id
 
+# v4 validation works
+
+    Code
+      extract_error_tbl_cols(v4_fail)
+    Output
+      # A tibble: 6 x 1
+        message                                  
+        <chr>                                    
+      1 must NOT have additional properties      
+      2 must NOT have additional properties      
+      3 must have required property 'is_required'
+      4 must be null                             
+      5 must have required property 'is_required'
+      6 must NOT have additional properties      
+
+---
+
+    Code
+      extract_error_tbl_cols(v4_fail_dynamic, c("message", "data"))
+    Output
+      # A tibble: 2 x 2
+        message                                                                data   
+        <chr>                                                                  <chr>  
+      1 derived_task_ids values MUST MATCH valid round task_id variable names  target~
+      2 derived_task_ids values MUST MATCH valid config task_id variable names random~
+

--- a/tests/testthat/helper-view-val-tbl.R
+++ b/tests/testthat/helper-view-val-tbl.R
@@ -1,3 +1,10 @@
+extract_error_tbl_cols <- function(x, cols = c(
+  "message"
+)) {
+  attr(x, "errors")[cols] |>
+    tibble::as_tibble()
+}
+
 expect_tab <- function(tab) {
   # Expect that the object has the correct classes
   expect_s3_class(tab, "gt_tbl")

--- a/tests/testthat/test-get_error_path.R
+++ b/tests/testthat/test-get_error_path.R
@@ -105,3 +105,51 @@ test_that("Creating instance paths works correctly", {
     "/rounds/0/model_tasks/1/target_metadata/0/target_keys"
   )
 })
+
+
+test_that("Paths with miltiple potential matches at different depths created correctly", {
+  # TODO: Remove `br-v4.0.0` branch in schema URL when v4.0.0 released.
+  schema <- hubUtils::get_schema(
+    "https://raw.githubusercontent.com/hubverse-org/schemas/br-v4.0.0/v4.0.0/tasks-schema.json"
+  )
+  # Top level match returned by default.
+  expect_equal(
+    get_error_path(
+      schema, "rounds/items/properties/derived_task_ids",
+      "schema"
+    ),
+    "#/properties/rounds/items/properties/derived_task_ids"
+  )
+  # Lower level match returned when fuller path provided.
+  expect_equal(
+    get_error_path(
+      schema, "derived_task_ids",
+      "schema"
+    ),
+    "#/properties/derived_task_ids"
+  )
+  # Top level match returned by default. `round_i` ignored
+  expect_equal(
+    glue::glue_data(
+      list(round_i = 1L),
+      get_error_path(
+        schema,
+        "derived_task_ids",
+        "instance"
+      )
+    ),
+    "/derived_task_ids"
+  )
+  # Lower level match returned when fuller path provided. `round_i` interpolated
+  expect_equal(
+    glue::glue_data(
+      list(round_i = 1L),
+      get_error_path(
+        schema,
+        "rounds/items/properties/derived_task_ids",
+        "instance"
+      )
+    ),
+    "/rounds/0/derived_task_ids"
+  )
+})

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -1,4 +1,5 @@
 test_that("Config validated successfully", {
+  skip_if_offline()
   expect_true(suppressMessages(validate_config(
     hub_path = system.file(
       "testhubs/simple/",
@@ -25,6 +26,7 @@ test_that("Config validated successfully", {
 
 
 test_that("Config for samples handled succesfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-samples-pass.json")
   out <- suppressMessages(validate_config(
     config_path = config_path,
@@ -34,6 +36,7 @@ test_that("Config for samples handled succesfully", {
   expect_true(out)
 })
 test_that("Missing files returns an invalid config with an immediate message", {
+  skip_if_offline()
   tmp <- withr::local_tempdir()
   suppressMessages({
     expect_message(out <- validate_config(hub_path = tmp), "File does not exist")
@@ -41,6 +44,7 @@ test_that("Missing files returns an invalid config with an immediate message", {
   expect_false(out)
 })
 test_that("Config for samples fail correctly", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-samples-error-range.json")
   out <- suppressWarnings(validate_config(
     config_path = config_path,
@@ -63,6 +67,7 @@ test_that("Config for samples fail correctly", {
 
 
 test_that("Config errors detected successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-errors.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -72,6 +77,7 @@ test_that("Config errors detected successfully", {
 
 
 test_that("Dynamic config errors detected successfully by custom R validation", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-errors-rval.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -80,6 +86,7 @@ test_that("Dynamic config errors detected successfully by custom R validation", 
 })
 
 test_that("Reserved hub variable task id name detected correctly", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-errors-rval-reserved.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -88,6 +95,7 @@ test_that("Reserved hub variable task id name detected correctly", {
 })
 
 test_that("NULL target keys validated successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks_null_rval.json")
   out <- suppressMessages(validate_config(config_path = config_path))
   expect_true(out)
@@ -95,12 +103,14 @@ test_that("NULL target keys validated successfully", {
 
 
 test_that("Bad schema_version URL errors successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "schema_version-errors.json")
   expect_error(validate_config(config_path = config_path))
 })
 
 
 test_that("Additional properties error successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-addprop.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -110,6 +120,7 @@ test_that("Additional properties error successfully", {
 
 
 test_that("Duplicate values in individual array error successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "dup-in-array.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -118,6 +129,7 @@ test_that("Duplicate values in individual array error successfully", {
 })
 
 test_that("Duplicate values across property error successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "dup-in-property.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -126,6 +138,7 @@ test_that("Duplicate values across property error successfully", {
 })
 
 test_that("Inconsistent round ID variables across model tasks error successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "round-id-inconsistent.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -141,6 +154,7 @@ test_that("Inconsistent round ID variables across model tasks error successfully
 
 
 test_that("Duplicate round ID values across rounds error successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "dup-in-round-id.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -149,6 +163,7 @@ test_that("Duplicate round ID values across rounds error successfully", {
 })
 
 test_that("All null task IDs error successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "both_null_tasks_all.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -157,6 +172,7 @@ test_that("All null task IDs error successfully", {
 })
 
 test_that("Old orgname config validates successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "task-old-orgname.json")
   out <- suppressMessages(validate_config(config_path = config_path))
   expect_snapshot(out)
@@ -165,6 +181,7 @@ test_that("Old orgname config validates successfully", {
 })
 
 test_that("target keys error if arrays passed", {
+  skip_if_offline()
   config_path <- testthat::test_path(
     "testdata",
     "tasks-target-key-array-v4.json"
@@ -188,4 +205,45 @@ test_that("target keys error if arrays passed", {
   # but not about target keys.
   expect_snapshot(attr(out_v3, "errors"))
   expect_false(out_v3)
+})
+
+test_that("v4 validation works", {
+  skip_if_offline()
+  config_path <- testthat::test_path(
+    "testdata",
+    "v4-tasks.json"
+  )
+  expect_true(
+    suppressMessages(
+      validate_config(
+        config_path = config_path,
+        branch = "br-v4.0.0"
+      )
+    )
+  )
+  config_path <- testthat::test_path("testdata", "v4-tasks-fail.json")
+  expect_false(
+    suppressMessages(
+      v4_fail <- validate_config(config_path = config_path, branch = "br-v4.0.0")
+    )
+  )
+  expect_snapshot(extract_error_tbl_cols(v4_fail))
+
+  # Ensure dynamic validation works and catches invalid derived task IDs at config
+  # and round level.
+  config_path <- testthat::test_path("testdata", "v4-tasks-fail-dynamic.json")
+  expect_false(
+    suppressMessages(
+      v4_fail_dynamic <- validate_config(config_path = config_path, branch = "br-v4.0.0")
+    )
+  )
+  expect_snapshot(
+    extract_error_tbl_cols(v4_fail_dynamic, c(
+      "message", "data"
+    ))
+  )
+  expect_equal(
+    extract_error_tbl_cols(v4_fail_dynamic, c("instancePath"))$instancePath,
+    structure(c("/rounds/0/derived_task_ids", "/derived_task_ids"), class = c("glue", "character"))
+  )
 })

--- a/tests/testthat/testdata/v4-tasks-fail-dynamic.json
+++ b/tests/testthat/testdata/v4-tasks-fail-dynamic.json
@@ -1,0 +1,155 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
+    "rounds": [{
+            "round_id_from_variable": true,
+            "round_id": "forecast_date",
+            "model_tasks": [{
+                "task_ids": {
+                    "forecast_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-12", "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01"
+                        ]
+                    },
+                    "target": {
+                        "required": null,
+                        "optional": ["wk ahead inc flu hosp"]
+                    },
+                    "horizon": {
+                        "required": [2],
+                        "optional": [1]
+                    },
+                    "location": {
+                        "required": ["US"],
+                        "optional": [
+                            "01",
+                            "02"
+                        ]
+                    },
+                    "target_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01", "2023-05-08", "2023-05-15"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "sample": {
+                        "output_type_id_params": {
+                            "type": "character",
+                            "min_samples_per_task": 50,
+                            "max_samples_per_task": 100,
+                            "max_length": 10
+                        },
+                        "is_required": true,
+                        "value": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    "mean": {
+                        "output_type_id": {
+                            "required": null
+                        },
+                        "is_required": true,
+                        "value": {
+                            "type": "double",
+                            "minimum": 0
+                        }
+                    }
+                },
+                "target_metadata": [{
+                    "target_id": "wk ahead inc flu hosp",
+                    "target_name": "weekly influenza hospitalization incidence",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": {
+                        "target": "wk ahead inc flu hosp"
+                    },
+                    "target_type": "discrete",
+                    "description": "This target represents the counts of new hospitalizations per horizon week.",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                }]
+            }, {
+                "task_ids": {
+                    "forecast_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-12", "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01"
+                        ]
+                    },
+                    "target": {
+                        "required": null,
+                        "optional": ["wk flu hosp rate change"]
+                    },
+                    "horizon": {
+                        "required": [2],
+                        "optional": [1]
+                    },
+                    "location": {
+                        "required": ["US"],
+                        "optional": [
+                            "01",
+                            "02"
+                        ]
+                    },
+                    "target_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01", "2023-05-08", "2023-05-15"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "pmf": {
+                        "output_type_id": {
+                            "required": ["large_decrease", "decrease", "stable", "increase", "large_increase"]
+                        },
+                        "is_required": false,
+                        "value": {
+                            "type": "double",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                },
+                "target_metadata": [{
+                    "target_id": "wk flu hosp rate change",
+                    "target_name": "weekly influenza hospitalization rate change",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": {
+                        "target": "wk flu hosp rate change"
+                    },
+                    "target_type": "nominal",
+                    "description": "This target represents the change in the rate of new hospitalizations per week comparing the week ending two days prior to the forecast_date to the week ending h weeks after the forecast_date.",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                }]
+            }],
+            "submissions_due": {
+                "relative_to": "forecast_date",
+                "start": -6,
+                "end": 2
+            },
+            "derived_task_ids": ["target_end_date"]
+        }
+
+    ],
+    "derived_task_ids": ["target_date", "random_task_id"]
+}

--- a/tests/testthat/testdata/v4-tasks-fail.json
+++ b/tests/testthat/testdata/v4-tasks-fail.json
@@ -1,0 +1,165 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
+    "rounds": [{
+            "round_id_from_variable": true,
+            "round_id": "forecast_date",
+            "model_tasks": [{
+                "task_ids": {
+                    "forecast_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-12", "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01"
+                        ]
+                    },
+                    "target": {
+                        "required": null,
+                        "optional": ["wk ahead inc flu hosp"]
+                    },
+                    "horizon": {
+                        "required": [2],
+                        "optional": [1]
+                    },
+                    "location": {
+                        "required": ["US"],
+                        "optional": [
+                            "01",
+                            "02"
+                        ]
+                    },
+                    "target_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01", "2023-05-08", "2023-05-15"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "sample": {
+                        "output_type_id_params": {
+                            "type": "character",
+                            "is_required": true,
+                            "min_samples_per_task": 50,
+                            "max_samples_per_task": 100,
+                            "max_length": 10
+                        },
+                        "value": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    "mean": {
+                        "output_type_id": {
+                            "required": null,
+                            "optional": ["NA"],
+                            "random_property": true
+                        },
+                        "is_required": true,
+                        "value": {
+                            "type": "double",
+                            "minimum": 0
+                        }
+                    },
+                    "median": {
+                        "output_type_id": {
+                            "required": ["NA"]
+                        },
+                        "value": {
+                            "type": "double",
+                            "minimum": 0
+                        }
+                    }
+                },
+                "target_metadata": [{
+                    "target_id": "wk ahead inc flu hosp",
+                    "target_name": "weekly influenza hospitalization incidence",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": {
+                        "target": "wk ahead inc flu hosp"
+                    },
+                    "target_type": "discrete",
+                    "description": "This target represents the counts of new hospitalizations per horizon week.",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                }]
+            }, {
+                "task_ids": {
+                    "forecast_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-12", "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01"
+                        ]
+                    },
+                    "target": {
+                        "required": null,
+                        "optional": ["wk flu hosp rate change"]
+                    },
+                    "horizon": {
+                        "required": [2],
+                        "optional": [1]
+                    },
+                    "location": {
+                        "required": ["US"],
+                        "optional": [
+                            "01",
+                            "02"
+                        ]
+                    },
+                    "target_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01", "2023-05-08", "2023-05-15"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "pmf": {
+                        "output_type_id": {
+                            "required": ["large_decrease", "decrease", "stable", "increase", "large_increase"]
+                        },
+                        "is_required": false,
+                        "value": {
+                            "type": "double",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                },
+                "target_metadata": [{
+                    "target_id": "wk flu hosp rate change",
+                    "target_name": "weekly influenza hospitalization rate change",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": {
+                        "target": "wk flu hosp rate change"
+                    },
+                    "target_type": "nominal",
+                    "description": "This target represents the change in the rate of new hospitalizations per week comparing the week ending two days prior to the forecast_date to the week ending h weeks after the forecast_date.",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                }]
+            }],
+            "submissions_due": {
+                "relative_to": "forecast_date",
+                "start": -6,
+                "end": 2
+            },
+            "derived_task_ids": ["target_end_date"]
+        }
+
+    ]
+}

--- a/tests/testthat/testdata/v4-tasks.json
+++ b/tests/testthat/testdata/v4-tasks.json
@@ -1,0 +1,154 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
+    "rounds": [{
+            "round_id_from_variable": true,
+            "round_id": "forecast_date",
+            "model_tasks": [{
+                "task_ids": {
+                    "forecast_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-12", "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01"
+                        ]
+                    },
+                    "target": {
+                        "required": null,
+                        "optional": ["wk ahead inc flu hosp"]
+                    },
+                    "horizon": {
+                        "required": [2],
+                        "optional": [1]
+                    },
+                    "location": {
+                        "required": ["US"],
+                        "optional": [
+                            "01",
+                            "02"
+                        ]
+                    },
+                    "target_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01", "2023-05-08", "2023-05-15"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "sample": {
+                        "output_type_id_params": {
+                            "type": "character",
+                            "min_samples_per_task": 50,
+                            "max_samples_per_task": 100,
+                            "max_length": 10
+                        },
+                        "is_required": true,
+                        "value": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    "mean": {
+                        "output_type_id": {
+                            "required": null
+                        },
+                        "is_required": true,
+                        "value": {
+                            "type": "double",
+                            "minimum": 0
+                        }
+                    }
+                },
+                "target_metadata": [{
+                    "target_id": "wk ahead inc flu hosp",
+                    "target_name": "weekly influenza hospitalization incidence",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": {
+                        "target": "wk ahead inc flu hosp"
+                    },
+                    "target_type": "discrete",
+                    "description": "This target represents the counts of new hospitalizations per horizon week.",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                }]
+            }, {
+                "task_ids": {
+                    "forecast_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-12", "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01"
+                        ]
+                    },
+                    "target": {
+                        "required": null,
+                        "optional": ["wk flu hosp rate change"]
+                    },
+                    "horizon": {
+                        "required": [2],
+                        "optional": [1]
+                    },
+                    "location": {
+                        "required": ["US"],
+                        "optional": [
+                            "01",
+                            "02"
+                        ]
+                    },
+                    "target_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01", "2023-05-08", "2023-05-15"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "pmf": {
+                        "output_type_id": {
+                            "required": ["large_decrease", "decrease", "stable", "increase", "large_increase"]
+                        },
+                        "is_required": false,
+                        "value": {
+                            "type": "double",
+                            "minimum": 0,
+                            "maximum": 1
+                        }
+                    }
+                },
+                "target_metadata": [{
+                    "target_id": "wk flu hosp rate change",
+                    "target_name": "weekly influenza hospitalization rate change",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": {
+                        "target": "wk flu hosp rate change"
+                    },
+                    "target_type": "nominal",
+                    "description": "This target represents the change in the rate of new hospitalizations per week comparing the week ending two days prior to the forecast_date to the week ending h weeks after the forecast_date.",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                }]
+            }],
+            "submissions_due": {
+                "relative_to": "forecast_date",
+                "start": -6,
+                "end": 2
+            },
+            "derived_task_ids": ["target_date"]
+        }
+
+    ]
+}


### PR DESCRIPTION
This PR resolves #69 by adding dynamic validation checks to ensure derived task ID match valid task ID names at the config and/or round level.

All other v4 schema changes are captured by `jsonvalidate` validation.

The PR also adds test v4 task.json config files and tests.

I've also minorly refactored and added documentation to the `get_error_path()`. Also, now when multiple matching paths to the required property are found (which has now been introduced with the config and round level `derived_task_ids` properties), the function returns the first match at the highest depth.