### PR TITLE
Use NULL point estimate output type IDs for v4 and later

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # hubAdmin (development version)
 
-* Support v4.0.0 schema configuration of output types and output type IDs when creating config files programmatically. Specifically, whether an output type is required or not is specified via the `is_required` logical property whereas the `output_type_id` values as provided through the `required` property.
+* Support v4.0.0 schema configuration of output types and output type IDs when creating config files programmatically. Specifically, whether an output type is required or not is specified via the `is_required` logical property whereas the `output_type_id` values as provided through the `required` property only (#53). In addition, `output_type_id` `required` value is now encoded as `NULL` instead of `NA` (#72).
+* Programmatically created higher level config elements now have a `branch` attributes that can be used to create and validate objects against a schema which is still in development and has not been released to the `main` branch yet.
 
 # hubAdmin 1.3.0
 

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -85,6 +85,8 @@ create_config <- function(rounds,
   rlang::check_required(rounds)
   check_object_class(rounds, "rounds")
   schema_id <- attr(rounds, "schema_id")
+  branch <- attr(rounds, "branch")
+
   if (!is.null(derived_task_ids)) {
     check_derived_task_ids(derived_task_ids, rounds = rounds)
   }
@@ -102,7 +104,8 @@ create_config <- function(rounds,
     ) %>% purrr::compact(), # remove output_type_id_datatype if NULL
     class = c("config", "list"),
     type = "tasks",
-    schema_id = schema_id
+    schema_id = schema_id,
+    branch = branch
   )
 }
 

--- a/R/create_output_type_item.R
+++ b/R/create_output_type_item.R
@@ -101,7 +101,7 @@ create_output_type_point <- function(output_type = c("mean", "median"),
   if (!pre_v4) {
     output_type_id <- list(
       output_type_id = list(
-        required = NA_character_
+        required = NULL
       ),
       is_required = is_required
     )

--- a/R/schema_autobox.R
+++ b/R/schema_autobox.R
@@ -93,9 +93,14 @@ schema_autobox <- function(config, box_extra_paths = NULL) {
     )
   }
   schema_id <- attr(config, "schema_id")
-  schema <- download_tasks_schema(
-    hubUtils::extract_schema_version(schema_id)
-  )
+  schema_version <- hubUtils::extract_schema_version(schema_id)
+  # If we can extract a branch from the config object, use that.
+  # Otherwise, default to main
+  branch <- attr(config, "branch")
+  if (is.null(branch)) {
+    branch <- "main"
+  }
+  schema <- download_tasks_schema(schema_version, branch)
 
   # Get list of paths to config properties that can be arrays and may require
   # boxing.

--- a/R/view_config_val_errors.R
+++ b/R/view_config_val_errors.R
@@ -231,7 +231,7 @@ path_to_tree <- function(x) {
       paths[i] <- paste0(
         "\u2514",
         paste(rep("\u2500", times = i - 2),
-              collapse = ""
+          collapse = ""
         ),
         paths[i]
       )

--- a/tests/testthat/_snaps/create_config.md
+++ b/tests/testthat/_snaps/create_config.md
@@ -394,7 +394,7 @@
       $rounds[[1]]$model_tasks[[1]]$output_type$mean
       $rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id
       $rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id$required
-      [1] NA
+      NULL
       
       
       $rounds[[1]]$model_tasks[[1]]$output_type$mean$is_required

--- a/tests/testthat/_snaps/create_config.md
+++ b/tests/testthat/_snaps/create_config.md
@@ -108,6 +108,8 @@
       [1] "tasks"
       attr(,"schema_id")
       [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
+      attr(,"branch")
+      [1] "main"
 
 # create_config functions error correctly
 
@@ -230,6 +232,8 @@
       [1] "tasks"
       attr(,"schema_id")
       [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
+      attr(,"branch")
+      [1] "main"
 
 ---
 
@@ -344,6 +348,8 @@
       [1] "tasks"
       attr(,"schema_id")
       [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
+      attr(,"branch")
+      [1] "main"
 
 # create_config derived_task_ids argument
 
@@ -459,6 +465,8 @@
       [1] "tasks"
       attr(,"schema_id")
       [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      attr(,"branch")
+      [1] "br-v4.0.0"
 
 ---
 

--- a/tests/testthat/_snaps/create_output_type_item.md
+++ b/tests/testthat/_snaps/create_output_type_item.md
@@ -553,7 +553,7 @@
       $mean
       $mean$output_type_id
       $mean$output_type_id$required
-      [1] NA
+      NULL
       
       
       $mean$is_required
@@ -584,7 +584,7 @@
       $mean
       $mean$output_type_id
       $mean$output_type_id$required
-      [1] NA
+      NULL
       
       
       $mean$is_required
@@ -615,7 +615,7 @@
       $median
       $median$output_type_id
       $median$output_type_id$required
-      [1] NA
+      NULL
       
       
       $median$is_required

--- a/tests/testthat/_snaps/create_round.md
+++ b/tests/testthat/_snaps/create_round.md
@@ -316,7 +316,7 @@
       $model_tasks[[1]]$output_type$mean
       $model_tasks[[1]]$output_type$mean$output_type_id
       $model_tasks[[1]]$output_type$mean$output_type_id$required
-      [1] NA
+      NULL
       
       
       $model_tasks[[1]]$output_type$mean$is_required

--- a/tests/testthat/_snaps/write_config.md
+++ b/tests/testthat/_snaps/write_config.md
@@ -356,3 +356,75 @@
         ]
       }
 
+# write_config with v4 works
+
+    Code
+      write_config(config = config, hub_path = temp_hub)
+    Message
+      v `config` written out successfully.
+
+---
+
+    Code
+      cat(readLines(file.path(temp_hub, "hub-config/tasks.json")), sep = "\n")
+    Output
+      {
+        "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
+        "rounds": [
+          {
+            "round_id_from_variable": true,
+            "round_id": "origin_date",
+            "model_tasks": [
+              {
+                "task_ids": {
+                  "origin_date": {
+                    "required": null,
+                    "optional": ["2023-01-02", "2023-01-09", "2023-01-16"]
+                  },
+                  "location": {
+                    "required": [
+                      "US"
+                    ],
+                    "optional": ["01", "02", "04", "05", "06"]
+                  },
+                  "horizon": {
+                    "required": [
+                      1
+                    ],
+                    "optional": [2, 3, 4]
+                  }
+                },
+                "output_type": {
+                  "mean": {
+                    "output_type_id": {
+                      "required": null
+                    },
+                    "is_required": true,
+                    "value": {
+                      "type": "double",
+                      "minimum": 0
+                    }
+                  }
+                },
+                "target_metadata": [
+                  {
+                    "target_id": "inc hosp",
+                    "target_name": "Weekly incident influenza hospitalizations",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": null,
+                    "target_type": "discrete",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                  }
+                ]
+              }
+            ],
+            "submissions_due": {
+              "relative_to": "origin_date",
+              "start": -4,
+              "end": 2
+            }
+          }
+        ]
+      }
+

--- a/tests/testthat/helper-write_config.R
+++ b/tests/testthat/helper-write_config.R
@@ -1,5 +1,5 @@
 # Setup fixtures for creating test objects
-create_test_rounds <- function() {
+create_test_rounds <- function(branch = "main", version = "v3.0.1") {
   create_rounds(
     create_round(
       round_id_from_variable = TRUE,
@@ -13,22 +13,30 @@ create_test_rounds <- function() {
                 "2023-01-02",
                 "2023-01-09",
                 "2023-01-16"
-              )
+              ),
+              branch = branch,
+              schema_version = version
             ),
             create_task_id("location",
               required = "US",
-              optional = c("01", "02", "04", "05", "06")
+              optional = c("01", "02", "04", "05", "06"),
+              branch = branch,
+              schema_version = version
             ),
             create_task_id("horizon",
               required = 1L,
-              optional = 2:4
+              optional = 2:4,
+              branch = branch,
+              schema_version = version
             )
           ),
           output_type = create_output_type(
             create_output_type_mean(
               is_required = TRUE,
               value_type = "double",
-              value_minimum = 0L
+              value_minimum = 0L,
+              branch = branch,
+              schema_version = version
             )
           ),
           target_metadata = create_target_metadata(
@@ -39,7 +47,9 @@ create_test_rounds <- function() {
               target_keys = NULL,
               target_type = "discrete",
               is_step_ahead = TRUE,
-              time_unit = "week"
+              time_unit = "week",
+              branch = branch,
+              schema_version = version
             )
           )
         )

--- a/tests/testthat/test-write_config.R
+++ b/tests/testthat/test-write_config.R
@@ -193,3 +193,30 @@ test_that("write_config with box_extra_paths works", {
     expect_true(suppressMessages(validate_config()))
   })
 })
+
+test_that("write_config with v4 works", {
+  # TODO: Remove references to br-v4.0.0 when v4.0.0 released
+  skip_if_offline()
+  rounds <- create_test_rounds(branch = "br-v4.0.0", version = "v4.0.0")
+  config <- create_test_config(rounds)
+  temp_hub <- setup_test_hub()
+  setup_test_hub_with_config_dir(temp_hub)
+
+  # Move to temp hub working directory to use default hub_path "." setting.
+  withr::with_dir(temp_hub, {
+    expect_snapshot(
+      write_config(
+        config = config,
+        hub_path = temp_hub
+      )
+    )
+    expect_true(
+      suppressMessages(
+        validate_config(hub_path = temp_hub, branch = "br-v4.0.0")
+      )
+    )
+    expect_snapshot(
+      cat(readLines(file.path(temp_hub, "hub-config/tasks.json")), sep = "\n")
+    )
+  })
+})


### PR DESCRIPTION
Resolves #72 

I'va also added tests that include writing out and validating v4 config files.

I've also added `branch` as an attribute to `config` class objects so we can use under development schema when auto-unboxing and writing config objects.

