### PR TITLE
skip tests that require a connection if offline

### DIFF
--- a/tests/testthat/test-append_round.R
+++ b/tests/testthat/test-append_round.R
@@ -1,4 +1,5 @@
 test_that("append_round works", {
+  skip_if_offline()
   config <- hubUtils::read_config_file(
     config_path = test_path("testdata/tasks-append.json")
   )
@@ -18,6 +19,7 @@ test_that("append_round works", {
 })
 
 test_that("append_round fails with duplicate round_ids", {
+  skip_if_offline()
   config <- hubUtils::read_config_file(
     config_path = test_path("testdata/tasks-append.json")
   )
@@ -29,6 +31,7 @@ test_that("append_round fails with duplicate round_ids", {
 })
 
 test_that("append_round fails with schema_id mismatch", {
+  skip_if_offline()
   config <- hubUtils::read_config_file(
     config_path = test_path("testdata/tasks-append.json")
   )

--- a/tests/testthat/test-check_properties.R
+++ b/tests/testthat/test-check_properties.R
@@ -1,4 +1,5 @@
 test_that("check_properties_scalar works", {
+  skip_if_offline()
   properties <- create_example_properties()
   schema <- download_tasks_schema("v3.0.1")
   round_schema <- get_schema_round(schema)
@@ -21,6 +22,7 @@ test_that("check_properties_scalar works", {
 })
 
 test_that("check_properties_array works", {
+  skip_if_offline()
   properties <- create_example_properties()
   schema <- download_tasks_schema("v3.0.1")
   round_schema <- get_schema_round(schema)

--- a/tests/testthat/test-create_config.R
+++ b/tests/testthat/test-create_config.R
@@ -1,4 +1,3 @@
-
 test_that("create_config functions work correctly", {
   skip_if_offline()
   rounds <- create_rounds(
@@ -9,20 +8,20 @@ test_that("create_config functions work correctly", {
         create_model_task(
           task_ids = create_task_ids(
             create_task_id("origin_date",
-                           required = NULL,
-                           optional = c(
-                             "2023-01-02",
-                             "2023-01-09",
-                             "2023-01-16"
-                           )
+              required = NULL,
+              optional = c(
+                "2023-01-02",
+                "2023-01-09",
+                "2023-01-16"
+              )
             ),
             create_task_id("location",
-                           required = "US",
-                           optional = c("01", "02", "04", "05", "06")
+              required = "US",
+              optional = c("01", "02", "04", "05", "06")
             ),
             create_task_id("horizon",
-                           required = 1L,
-                           optional = 2:4
+              required = 1L,
+              optional = 2:4
             )
           ),
           output_type = create_output_type(

--- a/tests/testthat/test-create_config.R
+++ b/tests/testthat/test-create_config.R
@@ -1,56 +1,57 @@
-rounds <- create_rounds(
-  create_round(
-    round_id_from_variable = TRUE,
-    round_id = "origin_date",
-    model_tasks = create_model_tasks(
-      create_model_task(
-        task_ids = create_task_ids(
-          create_task_id("origin_date",
-            required = NULL,
-            optional = c(
-              "2023-01-02",
-              "2023-01-09",
-              "2023-01-16"
-            )
-          ),
-          create_task_id("location",
-            required = "US",
-            optional = c("01", "02", "04", "05", "06")
-          ),
-          create_task_id("horizon",
-            required = 1L,
-            optional = 2:4
-          )
-        ),
-        output_type = create_output_type(
-          create_output_type_mean(
-            is_required = TRUE,
-            value_type = "double",
-            value_minimum = 0L
-          )
-        ),
-        target_metadata = create_target_metadata(
-          create_target_metadata_item(
-            target_id = "inc hosp",
-            target_name = "Weekly incident influenza hospitalizations",
-            target_units = "rate per 100,000 population",
-            target_keys = NULL,
-            target_type = "discrete",
-            is_step_ahead = TRUE,
-            time_unit = "week"
-          )
-        )
-      )
-    ),
-    submissions_due = list(
-      relative_to = "origin_date",
-      start = -4L,
-      end = 2L
-    )
-  )
-)
 
 test_that("create_config functions work correctly", {
+  skip_if_offline()
+  rounds <- create_rounds(
+    create_round(
+      round_id_from_variable = TRUE,
+      round_id = "origin_date",
+      model_tasks = create_model_tasks(
+        create_model_task(
+          task_ids = create_task_ids(
+            create_task_id("origin_date",
+                           required = NULL,
+                           optional = c(
+                             "2023-01-02",
+                             "2023-01-09",
+                             "2023-01-16"
+                           )
+            ),
+            create_task_id("location",
+                           required = "US",
+                           optional = c("01", "02", "04", "05", "06")
+            ),
+            create_task_id("horizon",
+                           required = 1L,
+                           optional = 2:4
+            )
+          ),
+          output_type = create_output_type(
+            create_output_type_mean(
+              is_required = TRUE,
+              value_type = "double",
+              value_minimum = 0L
+            )
+          ),
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = NULL,
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
+          )
+        )
+      ),
+      submissions_due = list(
+        relative_to = "origin_date",
+        start = -4L,
+        end = 2L
+      )
+    )
+  )
   expect_snapshot(
     create_config(rounds)
   )
@@ -58,6 +59,7 @@ test_that("create_config functions work correctly", {
 
 
 test_that("create_config functions error correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_config(list(a = 10)),
     error = TRUE
@@ -65,6 +67,7 @@ test_that("create_config functions error correctly", {
 })
 
 test_that("create_config handles output_type_id_datatype correctly ", {
+  skip_if_offline()
   test_rounds <- create_test_rounds()
   expect_null(
     create_config(test_rounds)$output_type_id_datatype
@@ -89,6 +92,7 @@ test_that("create_config handles output_type_id_datatype correctly ", {
 })
 
 test_that("create_config derived_task_ids argument", {
+  skip_if_offline()
   # TODO: Remove branch specification when v4.0.0 released
   expect_snapshot(
     create_config(

--- a/tests/testthat/test-create_model_task.R
+++ b/tests/testthat/test-create_model_task.R
@@ -1,4 +1,56 @@
 test_that("create_model_task functions work correctly", {
+  skip_if_offline()
+  rounds <- create_rounds(
+    create_round(
+      round_id_from_variable = TRUE,
+      round_id = "origin_date",
+      model_tasks = create_model_tasks(
+        create_model_task(
+          task_ids = create_task_ids(
+            create_task_id("origin_date",
+              required = NULL,
+              optional = c(
+                "2023-01-02",
+                "2023-01-09",
+                "2023-01-16"
+              )
+            ),
+            create_task_id("location",
+              required = "US",
+              optional = c("01", "02", "04", "05", "06")
+            ),
+            create_task_id("horizon",
+              required = 1L,
+              optional = 2:4
+            )
+          ),
+          output_type = create_output_type(
+            create_output_type_mean(
+              is_required = TRUE,
+              value_type = "double",
+              value_minimum = 0L
+            )
+          ),
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = NULL,
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
+          )
+        )
+      ),
+      submissions_due = list(
+        relative_to = "origin_date",
+        start = -4L,
+        end = 2L
+      )
+    )
+  )
   expect_snapshot(
     create_model_task(
       task_ids = create_task_ids(
@@ -159,33 +211,33 @@ test_that("create_model_task functions work correctly", {
   )
 })
 
-task_ids <- create_task_ids(
-  create_task_id("origin_date",
-    required = NULL,
-    optional = c(
-      "2023-01-02",
-      "2023-01-09",
-      "2023-01-16"
-    )
-  ),
-  create_task_id("target",
-    required = NULL,
-    optional = c("inc death", "inc hosp")
-  ),
-  create_task_id("horizon",
-    required = 1L,
-    optional = 2:4
-  )
-)
-output_type <- create_output_type(
-  create_output_type_mean(
-    is_required = TRUE,
-    value_type = "double",
-    value_minimum = 0L
-  )
-)
-
 test_that("create_output_type_point functions error correctly", {
+  skip_if_offline()
+  task_ids <- create_task_ids(
+    create_task_id("origin_date",
+      required = NULL,
+      optional = c(
+        "2023-01-02",
+        "2023-01-09",
+        "2023-01-16"
+      )
+    ),
+    create_task_id("target",
+      required = NULL,
+      optional = c("inc death", "inc hosp")
+    ),
+    create_task_id("horizon",
+      required = 1L,
+      optional = 2:4
+    )
+  )
+  output_type <- create_output_type(
+    create_output_type_mean(
+      is_required = TRUE,
+      value_type = "double",
+      value_minimum = 0L
+    )
+  )
   expect_snapshot(
     create_model_task(
       task_ids = task_ids,

--- a/tests/testthat/test-create_model_tasks.R
+++ b/tests/testthat/test-create_model_tasks.R
@@ -1,4 +1,5 @@
 test_that("create_model_tasks functions work correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_model_tasks(
       create_model_task(
@@ -163,6 +164,7 @@ test_that("create_model_tasks functions work correctly", {
 
 
 test_that("create_model_tasks functions error correctly", {
+  skip_if_offline()
   model_task_1 <- create_model_task(
     task_ids = create_task_ids(
       create_task_id("origin_date",

--- a/tests/testthat/test-create_output_type.R
+++ b/tests/testthat/test-create_output_type.R
@@ -1,4 +1,5 @@
 test_that("create_output_type functions work correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_output_type(
       create_output_type_mean(
@@ -25,6 +26,7 @@ test_that("create_output_type functions work correctly", {
 
 
 test_that("create_output_type functions error correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_output_type(
       create_output_type_mean(

--- a/tests/testthat/test-create_output_type_item.R
+++ b/tests/testthat/test-create_output_type_item.R
@@ -1,4 +1,5 @@
 test_that("create_output_type_point functions work correctly with v3.0.1 schema", {
+  skip_if_offline()
   expect_snapshot(
     create_output_type_mean(
       is_required = TRUE,
@@ -25,6 +26,7 @@ test_that("create_output_type_point functions work correctly with v3.0.1 schema"
 })
 
 test_that("create_output_type_point functions error correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_output_type_mean(
       is_required = "TRUE",
@@ -60,6 +62,7 @@ test_that("create_output_type_point functions error correctly", {
 })
 
 test_that("create_output_type_dist functions work correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_output_type_quantile(
       required = c(0.25, 0.5, 0.75),
@@ -121,6 +124,7 @@ test_that("create_output_type_dist functions work correctly", {
 
 
 test_that("create_output_type_dist functions error correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_output_type_cdf(
       required = NULL,
@@ -150,6 +154,7 @@ test_that("create_output_type_dist functions error correctly", {
 
 
 test_that("create_output_type_sample works", {
+  skip_if_offline()
   expect_snapshot(
     create_output_type_sample(
       is_required = TRUE,
@@ -188,6 +193,7 @@ test_that("create_output_type_sample works", {
 })
 
 test_that("create_output_type_sample errors correctly", {
+  skip_if_offline()
   # TODO: Remove branches when v4.0.0 is released
   # v4 type fails correctly
   expect_error(
@@ -288,6 +294,7 @@ test_that("create_output_type_sample errors correctly", {
 
 
 test_that("create_output_type_item is back-compatible", {
+  skip_if_offline()
   # Test back-compatibility
   expect_snapshot(
     create_output_type_median(
@@ -299,6 +306,7 @@ test_that("create_output_type_item is back-compatible", {
 })
 
 test_that("create_output_type_item works with v4 schema", {
+  skip_if_offline()
   # TODO: Remove branch argument when v4.0.0 is released
   expect_snapshot(
     create_output_type_mean(
@@ -330,6 +338,7 @@ test_that("create_output_type_item works with v4 schema", {
 
 
 test_that("create_output_type_dist fns support v4 schema", {
+  skip_if_offline()
   # TODO: Remove branch argument when v4.0.0 is released
 
   expect_snapshot(

--- a/tests/testthat/test-create_round.R
+++ b/tests/testthat/test-create_round.R
@@ -74,20 +74,20 @@ test_that("create_round name matching works correctly", {
     create_model_task(
       task_ids = create_task_ids(
         create_task_id("origin_date",
-                       required = NULL,
-                       optional = c(
-                         "2023-01-02",
-                         "2023-01-09",
-                         "2023-01-16"
-                       )
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
         ),
         create_task_id("location",
-                       required = "US",
-                       optional = c("01", "02", "04", "05", "06")
+          required = "US",
+          optional = c("01", "02", "04", "05", "06")
         ),
         create_task_id("horizon",
-                       required = 1L,
-                       optional = 2:4
+          required = 1L,
+          optional = 2:4
         )
       ),
       output_type = create_output_type(

--- a/tests/testthat/test-create_round.R
+++ b/tests/testthat/test-create_round.R
@@ -1,45 +1,45 @@
-model_tasks <- create_model_tasks(
-  create_model_task(
-    task_ids = create_task_ids(
-      create_task_id("origin_date",
-        required = NULL,
-        optional = c(
-          "2023-01-02",
-          "2023-01-09",
-          "2023-01-16"
+test_that("create_round functions work correctly", {
+  skip_if_offline()
+  model_tasks <- create_model_tasks(
+    create_model_task(
+      task_ids = create_task_ids(
+        create_task_id("origin_date",
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
+        ),
+        create_task_id("location",
+          required = "US",
+          optional = c("01", "02", "04", "05", "06")
+        ),
+        create_task_id("horizon",
+          required = 1L,
+          optional = 2:4
         )
       ),
-      create_task_id("location",
-        required = "US",
-        optional = c("01", "02", "04", "05", "06")
+      output_type = create_output_type(
+        create_output_type_mean(
+          is_required = TRUE,
+          value_type = "double",
+          value_minimum = 0L
+        )
       ),
-      create_task_id("horizon",
-        required = 1L,
-        optional = 2:4
-      )
-    ),
-    output_type = create_output_type(
-      create_output_type_mean(
-        is_required = TRUE,
-        value_type = "double",
-        value_minimum = 0L
-      )
-    ),
-    target_metadata = create_target_metadata(
-      create_target_metadata_item(
-        target_id = "inc hosp",
-        target_name = "Weekly incident influenza hospitalizations",
-        target_units = "rate per 100,000 population",
-        target_keys = NULL,
-        target_type = "discrete",
-        is_step_ahead = TRUE,
-        time_unit = "week"
+      target_metadata = create_target_metadata(
+        create_target_metadata_item(
+          target_id = "inc hosp",
+          target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population",
+          target_keys = NULL,
+          target_type = "discrete",
+          is_step_ahead = TRUE,
+          time_unit = "week"
+        )
       )
     )
   )
-)
-
-test_that("create_round functions work correctly", {
   expect_snapshot(
     create_round(
       round_id_from_variable = FALSE,
@@ -69,6 +69,47 @@ test_that("create_round functions work correctly", {
 
 
 test_that("create_round name matching works correctly", {
+  skip_if_offline()
+  model_tasks <- create_model_tasks(
+    create_model_task(
+      task_ids = create_task_ids(
+        create_task_id("origin_date",
+                       required = NULL,
+                       optional = c(
+                         "2023-01-02",
+                         "2023-01-09",
+                         "2023-01-16"
+                       )
+        ),
+        create_task_id("location",
+                       required = "US",
+                       optional = c("01", "02", "04", "05", "06")
+        ),
+        create_task_id("horizon",
+                       required = 1L,
+                       optional = 2:4
+        )
+      ),
+      output_type = create_output_type(
+        create_output_type_mean(
+          is_required = TRUE,
+          value_type = "double",
+          value_minimum = 0L
+        )
+      ),
+      target_metadata = create_target_metadata(
+        create_target_metadata_item(
+          target_id = "inc hosp",
+          target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population",
+          target_keys = NULL,
+          target_type = "discrete",
+          is_step_ahead = TRUE,
+          time_unit = "week"
+        )
+      )
+    )
+  )
   expect_snapshot(
     create_round(
       round_id_from_variable = FALSE,
@@ -140,6 +181,7 @@ test_that("create_round name matching works correctly", {
 })
 
 test_that("create_round derived_task_ids argument", {
+  skip_if_offline()
   # TODO: Remove branch specification when v4.0.0 released
   expect_snapshot(
     create_derived_task_ids_round(

--- a/tests/testthat/test-create_rounds.R
+++ b/tests/testthat/test-create_rounds.R
@@ -1,45 +1,45 @@
-model_tasks <- create_model_tasks(
-  create_model_task(
-    task_ids = create_task_ids(
-      create_task_id("origin_date",
-        required = NULL,
-        optional = c(
-          "2023-01-02",
-          "2023-01-09",
-          "2023-01-16"
+test_that("create_rounds functions work correctly", {
+  skip_if_offline()
+  model_tasks <- create_model_tasks(
+    create_model_task(
+      task_ids = create_task_ids(
+        create_task_id("origin_date",
+                       required = NULL,
+                       optional = c(
+                         "2023-01-02",
+                         "2023-01-09",
+                         "2023-01-16"
+                       )
+        ),
+        create_task_id("location",
+                       required = "US",
+                       optional = c("01", "02", "04", "05", "06")
+        ),
+        create_task_id("horizon",
+                       required = 1L,
+                       optional = 2:4
         )
       ),
-      create_task_id("location",
-        required = "US",
-        optional = c("01", "02", "04", "05", "06")
+      output_type = create_output_type(
+        create_output_type_mean(
+          is_required = TRUE,
+          value_type = "double",
+          value_minimum = 0L
+        )
       ),
-      create_task_id("horizon",
-        required = 1L,
-        optional = 2:4
-      )
-    ),
-    output_type = create_output_type(
-      create_output_type_mean(
-        is_required = TRUE,
-        value_type = "double",
-        value_minimum = 0L
-      )
-    ),
-    target_metadata = create_target_metadata(
-      create_target_metadata_item(
-        target_id = "inc hosp",
-        target_name = "Weekly incident influenza hospitalizations",
-        target_units = "rate per 100,000 population",
-        target_keys = NULL,
-        target_type = "discrete",
-        is_step_ahead = TRUE,
-        time_unit = "week"
+      target_metadata = create_target_metadata(
+        create_target_metadata_item(
+          target_id = "inc hosp",
+          target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population",
+          target_keys = NULL,
+          target_type = "discrete",
+          is_step_ahead = TRUE,
+          time_unit = "week"
+        )
       )
     )
   )
-)
-
-test_that("create_rounds functions work correctly", {
   expect_snapshot(
     create_rounds(
       create_round(
@@ -156,18 +156,58 @@ test_that("create_rounds functions work correctly", {
   )
 })
 
-round_1 <- create_round(
-  round_id_from_variable = FALSE,
-  round_id = "round_1",
-  model_tasks = model_tasks,
-  submissions_due = list(
-    start = "2023-01-12",
-    end = "2023-01-18"
-  ),
-  last_data_date = "2023-01-10"
-)
-
 test_that("create_round errors correctly", {
+  skip_if_offline()
+  model_tasks <- create_model_tasks(
+    create_model_task(
+      task_ids = create_task_ids(
+        create_task_id("origin_date",
+                       required = NULL,
+                       optional = c(
+                         "2023-01-02",
+                         "2023-01-09",
+                         "2023-01-16"
+                       )
+        ),
+        create_task_id("location",
+                       required = "US",
+                       optional = c("01", "02", "04", "05", "06")
+        ),
+        create_task_id("horizon",
+                       required = 1L,
+                       optional = 2:4
+        )
+      ),
+      output_type = create_output_type(
+        create_output_type_mean(
+          is_required = TRUE,
+          value_type = "double",
+          value_minimum = 0L
+        )
+      ),
+      target_metadata = create_target_metadata(
+        create_target_metadata_item(
+          target_id = "inc hosp",
+          target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population",
+          target_keys = NULL,
+          target_type = "discrete",
+          is_step_ahead = TRUE,
+          time_unit = "week"
+        )
+      )
+    )
+  )
+  round_1 <- create_round(
+    round_id_from_variable = FALSE,
+    round_id = "round_1",
+    model_tasks = model_tasks,
+    submissions_due = list(
+      start = "2023-01-12",
+      end = "2023-01-18"
+    ),
+    last_data_date = "2023-01-10"
+  )
   expect_snapshot(
     create_rounds(
       round_1,

--- a/tests/testthat/test-create_rounds.R
+++ b/tests/testthat/test-create_rounds.R
@@ -4,20 +4,20 @@ test_that("create_rounds functions work correctly", {
     create_model_task(
       task_ids = create_task_ids(
         create_task_id("origin_date",
-                       required = NULL,
-                       optional = c(
-                         "2023-01-02",
-                         "2023-01-09",
-                         "2023-01-16"
-                       )
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
         ),
         create_task_id("location",
-                       required = "US",
-                       optional = c("01", "02", "04", "05", "06")
+          required = "US",
+          optional = c("01", "02", "04", "05", "06")
         ),
         create_task_id("horizon",
-                       required = 1L,
-                       optional = 2:4
+          required = 1L,
+          optional = 2:4
         )
       ),
       output_type = create_output_type(
@@ -162,20 +162,20 @@ test_that("create_round errors correctly", {
     create_model_task(
       task_ids = create_task_ids(
         create_task_id("origin_date",
-                       required = NULL,
-                       optional = c(
-                         "2023-01-02",
-                         "2023-01-09",
-                         "2023-01-16"
-                       )
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
         ),
         create_task_id("location",
-                       required = "US",
-                       optional = c("01", "02", "04", "05", "06")
+          required = "US",
+          optional = c("01", "02", "04", "05", "06")
         ),
         create_task_id("horizon",
-                       required = 1L,
-                       optional = 2:4
+          required = 1L,
+          optional = 2:4
         )
       ),
       output_type = create_output_type(

--- a/tests/testthat/test-create_target_metadata.R
+++ b/tests/testthat/test-create_target_metadata.R
@@ -1,4 +1,5 @@
 test_that("create_target_metadata functions work correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_target_metadata(
       create_target_metadata_item(
@@ -25,6 +26,7 @@ test_that("create_target_metadata functions work correctly", {
 
 
 test_that("create_target_metadata functions error correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_target_metadata(
       create_target_metadata_item(

--- a/tests/testthat/test-create_target_metadata_item.R
+++ b/tests/testthat/test-create_target_metadata_item.R
@@ -1,4 +1,5 @@
 test_that("create_target_metadata_item functions work correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_target_metadata_item(
       target_id = "inc hosp",
@@ -24,6 +25,7 @@ test_that("create_target_metadata_item functions work correctly", {
 
 
 test_that("create_target_metadata_item functions error correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_target_metadata_item(
       target_id = "inc hosp",

--- a/tests/testthat/test-create_task_id.R
+++ b/tests/testthat/test-create_task_id.R
@@ -1,4 +1,5 @@
 test_that("create_task_id works correctly", {
+  skip_if_offline()
   expect_snapshot(create_task_id("horizon",
     required = 1L,
     optional = 2:4
@@ -36,6 +37,7 @@ test_that("create_task_id works correctly", {
 
 
 test_that("create_task_id errors correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_task_id("origin_date",
       required = NULL,
@@ -63,6 +65,7 @@ test_that("create_task_id errors correctly", {
 })
 
 test_that("create_task_id name matching works correctly", {
+  skip_if_offline()
   expect_equal(
     names(
       suppressMessages(

--- a/tests/testthat/test-create_task_ids.R
+++ b/tests/testthat/test-create_task_ids.R
@@ -1,4 +1,5 @@
 test_that("create_task_ids functions work correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_task_ids(
       create_task_id("origin_date",
@@ -34,6 +35,7 @@ test_that("create_task_ids functions work correctly", {
 
 
 test_that("create_task_ids functions error correctly", {
+  skip_if_offline()
   expect_snapshot(
     create_task_ids(
       create_task_id("origin_date",

--- a/tests/testthat/test-get_error_path.R
+++ b/tests/testthat/test-get_error_path.R
@@ -1,4 +1,5 @@
 test_that("Creating schema paths works correctly", {
+  skip_if_offline()
   schema <- hubUtils::get_schema(
     "https://raw.githubusercontent.com/hubverse-org/schemas/main/v1.0.0/tasks-schema.json"
   )
@@ -36,6 +37,7 @@ test_that("Creating schema paths works correctly", {
 })
 
 test_that("Creating instance paths works correctly", {
+  skip_if_offline()
   schema <- hubUtils::get_schema(
     "https://raw.githubusercontent.com/hubverse-org/schemas/main/v1.0.0/tasks-schema.json"
   )
@@ -108,6 +110,7 @@ test_that("Creating instance paths works correctly", {
 
 
 test_that("Paths with miltiple potential matches at different depths created correctly", {
+  skip_if_offline()
   # TODO: Remove `br-v4.0.0` branch in schema URL when v4.0.0 released.
   schema <- hubUtils::get_schema(
     "https://raw.githubusercontent.com/hubverse-org/schemas/br-v4.0.0/v4.0.0/tasks-schema.json"

--- a/tests/testthat/test-validate-inst-hubs.R
+++ b/tests/testthat/test-validate-inst-hubs.R
@@ -1,4 +1,5 @@
 test_that("simple example hub configured correctly", {
+  skip_if_offline()
   expect_true(
     all(
       unlist(
@@ -15,6 +16,7 @@ test_that("simple example hub configured correctly", {
 })
 
 test_that("flusight example hub configured correctly", {
+  skip_if_offline()
   expect_true(
     all(
       unlist(

--- a/tests/testthat/test-view_config_val_errors.R
+++ b/tests/testthat/test-view_config_val_errors.R
@@ -1,4 +1,5 @@
 test_that("Errors report launch successful", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-errors.json")
   validation <- suppressWarnings(
     validate_config(config_path = config_path)
@@ -19,6 +20,7 @@ test_that("Errors report launch successful", {
 })
 
 test_that("length 1 paths and related type & enum errors handled correctly", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "admin-errors2.json")
   # TODO - change branch back to main branch when
   validation <- suppressWarnings(
@@ -33,6 +35,7 @@ test_that("length 1 paths and related type & enum errors handled correctly", {
 })
 
 test_that("Data column handled correctly when required property missing", {
+  skip_if_offline()
   set.seed(1)
   # One nested property missing, one type error
   config_path <- testthat::test_path("testdata", "tasks_required_missing.json")
@@ -66,6 +69,7 @@ test_that("Data column handled correctly when required property missing", {
 })
 
 test_that("Report handles additional property errors successfully", {
+  skip_if_offline()
   config_path <- testthat::test_path("testdata", "tasks-addprop.json")
   out <- suppressWarnings(validate_config(config_path = config_path))
   tbl <- view_config_val_errors(out)
@@ -76,6 +80,7 @@ test_that("Report handles additional property errors successfully", {
 # validate_hub_config output ----
 
 test_that("Report works corectly on validate_hub_config output", {
+  skip_if_offline()
   config_dir <- system.file(
     "testhubs/simple/",
     package = "hubUtils"


### PR DESCRIPTION
I realised when I internet dropped for me for the 5th time today that the majority of the tests require internet but where not being skipped if not available. So I went through and added `skip_if_offline()` to all tests.