### PR TITLE
upgrade schema version to v5.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Use options to set `schema_version` and `branch` arguments in `download_tasks_schema()` and the `create_*()` family of functions for creating config files programmatically. This allows for setting the schema version and branch globally for the session (#85).
 * Make validation of `round_id` patterns explicit. This ties in with schema version v4.0.1 where the pattern the `round_id` property must match if `round_id_from_variable` is `false` is now specified as a regular expression in the schema. This check is also now implemented dynamically on values of the `round_id` variable if `round_id_from_variable` is `true` when validating tasks.json config files. Checks on `round_id` patterns are also now implemented in `create_round()` when creating rounds programmatically.
-* As of schema version v4.0.1, only a single `target_keys` element is allowed when creating target metadata items programmatically (#89).
+* As of schema version v5.0.0, only a single `target_keys` element is allowed when creating target metadata items programmatically (#89).
 
 # hubAdmin 1.4.0
 

--- a/R/create_target_metadata_item.R
+++ b/R/create_target_metadata_item.R
@@ -13,12 +13,13 @@
 #' @param target_units character string. Unit of observation of the target.
 #' @param target_keys named list or `NULL`. The `target_keys` value defines a
 #' single target.
-#' Should be `NULL` in the case where the target is not specified as a task_id
+#' Should be a named list containing a single character string element.
+#' The name of the element should match a `task_id` variable name within the same
+#' `model_tasks` object and the value should match a single value of that variable
+#' as described in
+#' [target metadata section of the official hubverse documentation](https://hubverse.io/en/latest/user-guide/tasks.html#target-metadata). # nolint: line_length_linter
+#' Otherwise, `NULL` in the case where the target is not specified as a task_id
 #' but is specified solely through the `target_id` argument.
-#' Otherwise, should be a named list containing a single character string element.
-#' The name of the element should match a `task_id`
-#' variable name within the same `model_tasks` object and the value should match
-#' a single value of that variable as described in [target metadata section of the official hubverse documentation](https://hubverse.io/en/latest/user-guide/tasks.html#target-metadata).
 #' @param description character string (optional). An optional verbose description
 #' of the target that might include information such as definitions of a 'rate' or similar.
 #' @param target_type character string. Target statistical data type. Consult the

--- a/R/create_target_metadata_item.R
+++ b/R/create_target_metadata_item.R
@@ -155,12 +155,12 @@ check_target_keys <- function(target_keys, schema_version,
       call = call
     )
   }
-  is_gte_v4_0_1 <- hubUtils::version_gte(
-    "v4.0.1",
+  is_gte_v5_0_0 <- hubUtils::version_gte(
+    "v5.0.0",
     schema_version = schema_version
   )
   target_key_n <- length(target_keys)
-  if (is_gte_v4_0_1 && target_key_n > 1L) {
+  if (is_gte_v5_0_0 && target_key_n > 1L) {
     cli::cli_abort(
       c(
         "!" = "{.arg target_keys} must be a named {.cls list} of

--- a/hubAdmin.Rproj
+++ b/hubAdmin.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: a853e49a-e7e8-463b-96b8-8c69e98c0382
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/man/create_target_metadata_item.Rd
+++ b/man/create_target_metadata_item.Rd
@@ -28,12 +28,13 @@ that could be used, for example, as a visualisation axis label.}
 
 \item{target_keys}{named list or \code{NULL}. The \code{target_keys} value defines a
 single target.
-Should be \code{NULL}, in the case where the target is not specified as a task_id
-but is specified solely through the \code{target_id} argument.
-Otherwise, should be a named list containing a single character string element.
-The name of the element should match a \code{task_id}
-variable name within the same \code{model_tasks} object and the value should match
-a single value of that variable.}
+Should be a named list containing a single character string element.
+The name of the element should match a \code{task_id} variable name within the same
+\code{model_tasks} object and the value should match a single value of that variable
+as described in
+\href{https://hubverse.io/en/latest/user-guide/tasks.html#target-metadata}{target metadata section of the official hubverse documentation}. # nolint: line_length_linter
+Otherwise, \code{NULL} in the case where the target is not specified as a task_id
+but is specified solely through the \code{target_id} argument.}
 
 \item{description}{character string (optional). An optional verbose description
 of the target that might include information such as definitions of a 'rate' or similar.}

--- a/tests/testthat/_snaps/create_target_metadata_item.md
+++ b/tests/testthat/_snaps/create_target_metadata_item.md
@@ -162,7 +162,7 @@
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
       + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
 
-# Target_keys of length more than 1 are not allowed post v4.0.1
+# Target_keys of length more than 1 are not allowed post v5.0.0
 
     Code
       create_target_metadata_item(target_id = "flu inc hosp", target_name = "Weekly incident influenza hospitalizations",

--- a/tests/testthat/test-create_round.R
+++ b/tests/testthat/test-create_round.R
@@ -229,8 +229,8 @@ test_that("validating round_id patterns when round_id_from_var = TRUE works", {
   skip_if_offline()
   withr::with_options(
     list(
-      hubAdmin.schema_version = "v4.0.1",
-      hubAdmin.branch = "br-v4.0.1"
+      hubAdmin.schema_version = "v5.0.0",
+      hubAdmin.branch = "br-v5.0.0"
     ),
     {
       output_types <- create_output_type(
@@ -372,8 +372,8 @@ test_that("validating round_id pattern when round_id_from_var = FALSE works", {
   skip_if_offline()
   withr::with_options(
     list(
-      hubAdmin.schema_version = "v4.0.1",
-      hubAdmin.branch = "br-v4.0.1"
+      hubAdmin.schema_version = "v5.0.0",
+      hubAdmin.branch = "br-v5.0.0"
     ),
     {
       output_types <- create_output_type(

--- a/tests/testthat/test-create_target_metadata_item.R
+++ b/tests/testthat/test-create_target_metadata_item.R
@@ -149,16 +149,16 @@ test_that("schema version option works for create_target_metadata_item", {
   expect_snapshot(waldo::compare(opt_version, version_default))
 })
 
-test_that("Target_keys of length more than 1 are not allowed post v4.0.1", {
+test_that("Target_keys of length more than 1 are not allowed post v5.0.0", {
   skip_if_offline()
   withr::with_options(
     list(
-      hubAdmin.schema_version = "v4.0.1",
-      # TDOD: remove branch argument when v4.0.1 is released.
-      hubAdmin.branch = "ak/v4.0.1/restrict-target-key-value-pair-n/117"
+      hubAdmin.schema_version = "v5.0.0",
+      # TDOD: remove branch argument when v5.0.0 is released.
+      hubAdmin.branch = "br-v5.0.0"
     ),
     {
-      # One target_key is allowed in v4.0.1 and later versions.
+      # One target_key is allowed in v5.0.0 and later versions.
       target_keys_n1 <- create_target_metadata_item(
         target_id = "inc hosp",
         target_name = "Weekly incident influenza hospitalizations",
@@ -171,7 +171,7 @@ test_that("Target_keys of length more than 1 are not allowed post v4.0.1", {
       expect_s3_class(target_keys_n1, "target_metadata_item")
       expect_length(target_keys_n1$target_keys, 1L)
 
-      # More than one target_key is NOT allowed in v4.0.1 and later versions
+      # More than one target_key is NOT allowed in v5.0.0 and later versions
       # and throws error.
       expect_snapshot(
         create_target_metadata_item(

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -253,14 +253,14 @@ test_that("v4 validation works", {
 })
 
 
-test_that("v4.0.1 target keys with 2 properties throws error", {
+test_that("v5.0.0 target keys with 2 properties throws error", {
   skip_if_offline()
-  config_path <- testthat::test_path("testdata", "v4.0.1-tasks-2-target_keys.json")
+  config_path <- testthat::test_path("testdata", "v5.0.0-tasks-2-target_keys.json")
   out <- suppressMessages(
     validate_config(
       config_path = config_path,
-      # TDOD: remove branch argument when v4.0.1 is released.
-      branch = "ak/v4.0.1/restrict-target-key-value-pair-n/117"
+      # TDOD: remove branch argument when v5.0.0 is released.
+      branch = "br-v5.0.0"
     )
   )
   expect_false(out)
@@ -272,23 +272,23 @@ test_that("v4.0.1 target keys with 2 properties throws error", {
   expect_equal(nrow(attr(out, "errors")), 2L)
 })
 
-test_that("v4.0.1 target keys with NULL properties passes", {
+test_that("v5.0.0 target keys with NULL properties passes", {
   # Ensure NULL target keys are still allowed.
-  config_path <- testthat::test_path("testdata", "v4.0.1-tasks-null-target_keys.json")
+  config_path <- testthat::test_path("testdata", "v5.0.0-tasks-null-target_keys.json")
   out <- suppressMessages(
     validate_config(
       config_path = config_path,
-      # TDOD: remove branch argument when v4.0.1 is released.
-      branch = "ak/v4.0.1/restrict-target-key-value-pair-n/117"
+      # TDOD: remove branch argument when v5.0.0 is released.
+      branch = "br-v5.0.0"
     )
   )
   expect_true(out)
 })
 
-test_that("v4.0.1 round_id pattern validation works", {
+test_that("v5.0.0 round_id pattern validation works", {
   skip_if_offline()
-  # TODO: remove branch argument when v4.0.1 is released.
-  schema <- download_tasks_schema("v4.0.1", branch = "br-v4.0.1")
+  # TODO: remove branch argument when v5.0.0 is released.
+  schema <- download_tasks_schema("v5.0.0", branch = "br-v5.0.0")
 
   # Test that regex pattern matching for round_id properties in jsonvalidate
   # identifies expected errors (when round_id_from_variable: false).
@@ -297,9 +297,9 @@ test_that("v4.0.1 round_id pattern validation works", {
       validate_config(
         config_path = testthat::test_path(
           "testdata",
-          "v4.0.1-tasks-fail-round-id-pattern.json"
+          "v5.0.0-tasks-fail-round-id-pattern.json"
         ),
-        branch = "br-v4.0.1"
+        branch = "br-v5.0.0"
       )
     )
   )
@@ -325,9 +325,9 @@ test_that("v4.0.1 round_id pattern validation works", {
       validate_config(
         config_path = testthat::test_path(
           "testdata",
-          "v4.0.1-tasks-fail-round-id-val-pattern.json"
+          "v5.0.0-tasks-fail-round-id-val-pattern.json"
         ),
-        branch = "br-v4.0.1"
+        branch = "br-v5.0.0"
       )
     )
   )

--- a/tests/testthat/testdata/v5.0.0-tasks-2-target_keys.json
+++ b/tests/testthat/testdata/v5.0.0-tasks-2-target_keys.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.1/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/tasks-schema.json",
     "rounds": [{
             "round_id_from_variable": true,
             "round_id": "forecast_date",

--- a/tests/testthat/testdata/v5.0.0-tasks-fail-round-id-pattern.json
+++ b/tests/testthat/testdata/v5.0.0-tasks-fail-round-id-pattern.json
@@ -1,17 +1,104 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.1/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/tasks-schema.json",
     "rounds": [{
             "round_id_from_variable": true,
             "round_id": "round_id_var",
             "model_tasks": [{
                 "task_ids": {
                     "round_id_var": {
-                        "required": ["invalid-round-id-in-var-req"],
+                        "required": null,
+                        "optional": ["24_25_covid", "invalid-round-id-in-var"]
+                    },
+                    "forecast_date": {
+                        "required": null,
                         "optional": [
-                            "24_25_covid",
-                            "invalid-round-id-in-var-opt1",
-                            "invalid-round-id-in-var-opt2"
-                            ]
+                            "2022-12-19", "2022-12-26",
+                            "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01"
+                        ]
+                    },
+                    "target": {
+                        "required": null,
+                        "optional": ["wk ahead inc flu hosp"]
+                    },
+                    "horizon": {
+                        "required": [2],
+                        "optional": [1]
+                    },
+                    "location": {
+                        "required": ["US"],
+                        "optional": [
+                            "01",
+                            "02"
+                        ]
+                    },
+                    "target_date": {
+                        "required": null,
+                        "optional": [
+                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
+                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
+                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
+                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
+                            "2023-05-01", "2023-05-08", "2023-05-15"
+                        ]
+                    }
+                },
+                "output_type": {
+                    "sample": {
+                        "output_type_id_params": {
+                            "type": "character",
+                            "min_samples_per_task": 50,
+                            "max_samples_per_task": 100,
+                            "max_length": 10
+                        },
+                        "is_required": true,
+                        "value": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    "mean": {
+                        "output_type_id": {
+                            "required": null
+                        },
+                        "is_required": true,
+                        "value": {
+                            "type": "double",
+                            "minimum": 0
+                        }
+                    }
+                },
+                "target_metadata": [{
+                    "target_id": "wk ahead inc flu hosp",
+                    "target_name": "weekly influenza hospitalization incidence",
+                    "target_units": "rate per 100,000 population",
+                    "target_keys": {
+                        "target": "wk ahead inc flu hosp"
+                    },
+                    "target_type": "discrete",
+                    "description": "This target represents the counts of new hospitalizations per horizon week.",
+                    "is_step_ahead": true,
+                    "time_unit": "week"
+                }]
+            }],
+            "submissions_due": {
+                "relative_to": "forecast_date",
+                "start": -6,
+                "end": 2
+            },
+            "derived_task_ids": ["target_date"]
+        },
+        {
+            "round_id_from_variable": false,
+            "round_id": "invalid-round-id",
+            "model_tasks": [{
+                "task_ids": {
+                    "round_id_var": {
+                        "required": null,
+                        "optional": null
                     },
                     "forecast_date": {
                         "required": null,

--- a/tests/testthat/testdata/v5.0.0-tasks-fail-round-id-val-pattern.json
+++ b/tests/testthat/testdata/v5.0.0-tasks-fail-round-id-val-pattern.json
@@ -1,104 +1,17 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.1/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/tasks-schema.json",
     "rounds": [{
             "round_id_from_variable": true,
             "round_id": "round_id_var",
             "model_tasks": [{
                 "task_ids": {
                     "round_id_var": {
-                        "required": null,
-                        "optional": ["24_25_covid", "invalid-round-id-in-var"]
-                    },
-                    "forecast_date": {
-                        "required": null,
+                        "required": ["invalid-round-id-in-var-req"],
                         "optional": [
-                            "2022-12-19", "2022-12-26",
-                            "2023-01-02", "2023-01-09",
-                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
-                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
-                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
-                            "2023-05-01"
-                        ]
-                    },
-                    "target": {
-                        "required": null,
-                        "optional": ["wk ahead inc flu hosp"]
-                    },
-                    "horizon": {
-                        "required": [2],
-                        "optional": [1]
-                    },
-                    "location": {
-                        "required": ["US"],
-                        "optional": [
-                            "01",
-                            "02"
-                        ]
-                    },
-                    "target_date": {
-                        "required": null,
-                        "optional": [
-                            "2022-12-19", "2022-12-26", "2023-01-02", "2023-01-09",
-                            "2023-01-16", "2023-01-23", "2023-01-30", "2023-02-06", "2023-02-13",
-                            "2023-02-20", "2023-02-27", "2023-03-06", "2023-03-13", "2023-03-20",
-                            "2023-03-27", "2023-04-03", "2023-04-10", "2023-04-17", "2023-04-24",
-                            "2023-05-01", "2023-05-08", "2023-05-15"
-                        ]
-                    }
-                },
-                "output_type": {
-                    "sample": {
-                        "output_type_id_params": {
-                            "type": "character",
-                            "min_samples_per_task": 50,
-                            "max_samples_per_task": 100,
-                            "max_length": 10
-                        },
-                        "is_required": true,
-                        "value": {
-                            "type": "integer",
-                            "minimum": 0
-                        }
-                    },
-                    "mean": {
-                        "output_type_id": {
-                            "required": null
-                        },
-                        "is_required": true,
-                        "value": {
-                            "type": "double",
-                            "minimum": 0
-                        }
-                    }
-                },
-                "target_metadata": [{
-                    "target_id": "wk ahead inc flu hosp",
-                    "target_name": "weekly influenza hospitalization incidence",
-                    "target_units": "rate per 100,000 population",
-                    "target_keys": {
-                        "target": "wk ahead inc flu hosp"
-                    },
-                    "target_type": "discrete",
-                    "description": "This target represents the counts of new hospitalizations per horizon week.",
-                    "is_step_ahead": true,
-                    "time_unit": "week"
-                }]
-            }],
-            "submissions_due": {
-                "relative_to": "forecast_date",
-                "start": -6,
-                "end": 2
-            },
-            "derived_task_ids": ["target_date"]
-        },
-        {
-            "round_id_from_variable": false,
-            "round_id": "invalid-round-id",
-            "model_tasks": [{
-                "task_ids": {
-                    "round_id_var": {
-                        "required": null,
-                        "optional": null
+                            "24_25_covid",
+                            "invalid-round-id-in-var-opt1",
+                            "invalid-round-id-in-var-opt2"
+                            ]
                     },
                     "forecast_date": {
                         "required": null,

--- a/tests/testthat/testdata/v5.0.0-tasks-null-target_keys.json
+++ b/tests/testthat/testdata/v5.0.0-tasks-null-target_keys.json
@@ -1,5 +1,5 @@
 {
-    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.1/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/tasks-schema.json",
     "rounds": [{
             "round_id_from_variable": true,
             "round_id": "forecast_date",


### PR DESCRIPTION
This PR build on #90 but changes all mention of v4.0.1 to v5.0.0.

I've also incorporated comments from the review in #90 

I'm opening the PR against the previous PR so you don't have to review the whole thing again and just focus on the changes related to bumping the schema to v5.0.0. I've ran the tests locally and by pointing to `main` first though and all tests pass. When I merge this into #90 I'll also make sure to re-run the tests before merging.

_Note: I have not yet made use of the new functionality in `hubUtils` for using local schema as the latest schema in `hubUtils` is currently v4.0.0 and would need a PR to `hubUtils` first. I reckon we can just update `hubUtils` straight to v5.0.0 on the main branch once it's merged instead of first to the dev branch and then to main_