### PR TITLE
Make latest snaphots version agnostic

### DIFF
--- a/R/append_round.R
+++ b/R/append_round.R
@@ -116,11 +116,67 @@
 #'   )
 #' )
 #' append_round(config, new_round)
-#' # Append in existing config file
+#' # Append in existing config file using an older schema version
+#' options(hubAdmin.schema_version = "v4.0.0")
 #' config <- hubUtils::read_config_file(
 #'   system.file("v4-tasks.json", package = "hubAdmin")
 #' )
+#' # Create new round using version defined through
+#' # hubAdmin.schema_version option
+#' new_round <- create_round(
+#'   round_id_from_variable = TRUE,
+#'   round_id = "origin_date",
+#'   model_tasks = create_model_tasks(
+#'     create_model_task(
+#'       task_ids = create_task_ids(
+#'         create_task_id("origin_date",
+#'           required = NULL,
+#'           optional = c(
+#'             "2023-01-23"
+#'           )
+#'         ),
+#'         create_task_id("location",
+#'           required = "US",
+#'           optional = c("01", "02", "04", "05", "06")
+#'         ),
+#'         create_task_id("horizon",
+#'           required = 1L,
+#'           optional = 2:4
+#'         ),
+#'         create_task_id("age_group",
+#'           required = NULL,
+#'           optional = c("1", "2", "3", "4", "5")
+#'         )
+#'       ),
+#'       output_type = create_output_type(
+#'         create_output_type_mean(
+#'           is_required = TRUE,
+#'           value_type = "double",
+#'           value_minimum = 0L
+#'         )
+#'       ),
+#'       target_metadata = create_target_metadata(
+#'         create_target_metadata_item(
+#'           target_id = "inc hosp",
+#'           target_name = "Weekly incident influenza hospitalizations",
+#'           target_units = "rate per 100,000 population",
+#'           target_keys = NULL,
+#'           target_type = "discrete",
+#'           is_step_ahead = TRUE,
+#'           time_unit = "week"
+#'         )
+#'       )
+#'     )
+#'   ),
+#'   submissions_due = list(
+#'     relative_to = "origin_date",
+#'     start = -4L,
+#'     end = 2L
+#'   )
+#' )
 #' append_round(config, new_round)
+#' # Reset option to latest schema version
+#' options(hubAdmin.schema_version = "latest")
 append_round <- function(config, ...) {
   checkmate::assert_class(config, "config")
 

--- a/man/append_round.Rd
+++ b/man/append_round.Rd
@@ -126,9 +126,65 @@ new_round <- create_round(
   )
 )
 append_round(config, new_round)
-# Append in existing config file
+# Append in existing config file using an older schema version
+options(hubAdmin.schema_version = "v4.0.0")
 config <- hubUtils::read_config_file(
   system.file("v4-tasks.json", package = "hubAdmin")
 )
+# Create new round using version defined through
+# hubAdmin.schema_version option
+new_round <- create_round(
+  round_id_from_variable = TRUE,
+  round_id = "origin_date",
+  model_tasks = create_model_tasks(
+    create_model_task(
+      task_ids = create_task_ids(
+        create_task_id("origin_date",
+          required = NULL,
+          optional = c(
+            "2023-01-23"
+          )
+        ),
+        create_task_id("location",
+          required = "US",
+          optional = c("01", "02", "04", "05", "06")
+        ),
+        create_task_id("horizon",
+          required = 1L,
+          optional = 2:4
+        ),
+        create_task_id("age_group",
+          required = NULL,
+          optional = c("1", "2", "3", "4", "5")
+        )
+      ),
+      output_type = create_output_type(
+        create_output_type_mean(
+          is_required = TRUE,
+          value_type = "double",
+          value_minimum = 0L
+        )
+      ),
+      target_metadata = create_target_metadata(
+        create_target_metadata_item(
+          target_id = "inc hosp",
+          target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population",
+          target_keys = NULL,
+          target_type = "discrete",
+          is_step_ahead = TRUE,
+          time_unit = "week"
+        )
+      )
+    )
+  ),
+  submissions_due = list(
+    relative_to = "origin_date",
+    start = -4L,
+    end = 2L
+  )
+)
 append_round(config, new_round)
+# Reset option to latest schema version
+options(hubAdmin.schema_version = "latest")
 }

--- a/tests/testthat/_snaps/create_config.md
+++ b/tests/testthat/_snaps/create_config.md
@@ -1,10 +1,10 @@
 # create_config functions work correctly
 
     Code
-      create_config(rounds)
+      verify_latest_schema_version(create_config(rounds))
     Output
       $schema_version
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       
       $rounds
       $rounds[[1]]
@@ -107,7 +107,7 @@
       attr(,"type")
       [1] "tasks"
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/create_model_task.md
+++ b/tests/testthat/_snaps/create_model_task.md
@@ -1,15 +1,16 @@
 # create_model_task functions work correctly
 
     Code
-      create_model_task(task_ids = create_task_ids(create_task_id("origin_date",
-        required = NULL, optional = c("2023-01-02", "2023-01-09", "2023-01-16")),
-      create_task_id("location", required = "US", optional = c("01", "02", "04", "05",
-        "06")), create_task_id("horizon", required = 1L, optional = 2:4)),
-      output_type = create_output_type(create_output_type_mean(is_required = TRUE,
-        value_type = "double", value_minimum = 0L)), target_metadata = create_target_metadata(
+      verify_latest_schema_version(create_model_task(task_ids = create_task_ids(
+        create_task_id("origin_date", required = NULL, optional = c("2023-01-02",
+          "2023-01-09", "2023-01-16")), create_task_id("location", required = "US",
+          optional = c("01", "02", "04", "05", "06")), create_task_id("horizon",
+          required = 1L, optional = 2:4)), output_type = create_output_type(
+        create_output_type_mean(is_required = TRUE, value_type = "double",
+          value_minimum = 0L)), target_metadata = create_target_metadata(
         create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
           target_units = "rate per 100,000 population", target_keys = NULL,
-          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))
+          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"))))
     Output
       $task_ids
       $task_ids$origin_date
@@ -85,26 +86,27 @@
       attr(,"class")
       [1] "model_task" "list"      
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_model_task(task_ids = create_task_ids(create_task_id("origin_date",
-        required = NULL, optional = c("2023-01-02", "2023-01-09", "2023-01-16")),
-      create_task_id("location", required = "US", optional = c("01", "02", "04", "05",
-        "06")), create_task_id("horizon", required = 1L, optional = 2:4)),
-      output_type = create_output_type(create_output_type_mean(is_required = TRUE,
-        value_type = "double", value_minimum = 0L), create_output_type_sample(
-        is_required = FALSE, output_type_id_type = "character", max_length = 5L,
-        min_samples_per_task = 70L, max_samples_per_task = 100L, compound_taskid_set = c(
-          "horizon", "origin_date"), value_type = "double", value_minimum = 0L,
-        value_maximum = 1L)), target_metadata = create_target_metadata(
-        create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
-          target_units = "rate per 100,000 population", target_keys = NULL,
-          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))
+      verify_latest_schema_version(create_model_task(task_ids = create_task_ids(
+        create_task_id("origin_date", required = NULL, optional = c("2023-01-02",
+          "2023-01-09", "2023-01-16")), create_task_id("location", required = "US",
+          optional = c("01", "02", "04", "05", "06")), create_task_id("horizon",
+          required = 1L, optional = 2:4)), output_type = create_output_type(
+        create_output_type_mean(is_required = TRUE, value_type = "double",
+          value_minimum = 0L), create_output_type_sample(is_required = FALSE,
+          output_type_id_type = "character", max_length = 5L, min_samples_per_task = 70L,
+          max_samples_per_task = 100L, compound_taskid_set = c("horizon",
+            "origin_date"), value_type = "double", value_minimum = 0L, value_maximum = 1L)),
+      target_metadata = create_target_metadata(create_target_metadata_item(target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations", target_units = "rate per 100,000 population",
+        target_keys = NULL, target_type = "discrete", is_step_ahead = TRUE,
+        time_unit = "week"))))
     Output
       $task_ids
       $task_ids$origin_date
@@ -213,29 +215,30 @@
       attr(,"class")
       [1] "model_task" "list"      
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_model_task(task_ids = create_task_ids(create_task_id("origin_date",
-        required = NULL, optional = c("2023-01-02", "2023-01-09", "2023-01-16")),
-      create_task_id("location", required = "US", optional = c("01", "02", "04", "05",
-        "06")), create_task_id("target", required = NULL, optional = c("inc death",
-        "inc hosp")), create_task_id("horizon", required = 1L, optional = 2:4)),
-      output_type = create_output_type(create_output_type_mean(is_required = TRUE,
-        value_type = "double", value_minimum = 0L), create_output_type_median(
-        is_required = FALSE, value_type = "double"), create_output_type_quantile(
-        required = c(0.1, 0.2, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9), is_required = TRUE,
-        value_type = "double", value_minimum = 0)), target_metadata = create_target_metadata(
+      verify_latest_schema_version(create_model_task(task_ids = create_task_ids(
+        create_task_id("origin_date", required = NULL, optional = c("2023-01-02",
+          "2023-01-09", "2023-01-16")), create_task_id("location", required = "US",
+          optional = c("01", "02", "04", "05", "06")), create_task_id("target",
+          required = NULL, optional = c("inc death", "inc hosp")), create_task_id(
+          "horizon", required = 1L, optional = 2:4)), output_type = create_output_type(
+        create_output_type_mean(is_required = TRUE, value_type = "double",
+          value_minimum = 0L), create_output_type_median(is_required = FALSE,
+          value_type = "double"), create_output_type_quantile(required = c(0.1, 0.2,
+          0.3, 0.4, 0.6, 0.7, 0.8, 0.9), is_required = TRUE, value_type = "double",
+        value_minimum = 0)), target_metadata = create_target_metadata(
         create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
           target_units = "rate per 100,000 population", target_keys = list(target = "inc hosp"),
           target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"),
         create_target_metadata_item(target_id = "inc death", target_name = "Weekly incident influenza deaths",
           target_units = "rate per 100,000 population", target_keys = list(target = "inc death"),
-          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))
+          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"))))
     Output
       $task_ids
       $task_ids$origin_date
@@ -379,7 +382,7 @@
       attr(,"class")
       [1] "model_task" "list"      
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/create_model_tasks.md
+++ b/tests/testthat/_snaps/create_model_tasks.md
@@ -1,16 +1,16 @@
 # create_model_tasks functions work correctly
 
     Code
-      create_model_tasks(create_model_task(task_ids = create_task_ids(create_task_id(
-        "origin_date", required = NULL, optional = c("2023-01-02", "2023-01-09",
-          "2023-01-16")), create_task_id("location", required = "US", optional = c(
-        "01", "02", "04", "05", "06")), create_task_id("horizon", required = 1L,
-        optional = 2:4)), output_type = create_output_type(create_output_type_mean(
-        is_required = TRUE, value_type = "double", value_minimum = 0L)),
-      target_metadata = create_target_metadata(create_target_metadata_item(target_id = "inc hosp",
-        target_name = "Weekly incident influenza hospitalizations", target_units = "rate per 100,000 population",
-        target_keys = NULL, target_type = "discrete", is_step_ahead = TRUE,
-        time_unit = "week"))))
+      verify_latest_schema_version(create_model_tasks(create_model_task(task_ids = create_task_ids(
+        create_task_id("origin_date", required = NULL, optional = c("2023-01-02",
+          "2023-01-09", "2023-01-16")), create_task_id("location", required = "US",
+          optional = c("01", "02", "04", "05", "06")), create_task_id("horizon",
+          required = 1L, optional = 2:4)), output_type = create_output_type(
+        create_output_type_mean(is_required = TRUE, value_type = "double",
+          value_minimum = 0L)), target_metadata = create_target_metadata(
+        create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population", target_keys = NULL,
+          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))))
     Output
       $model_tasks
       $model_tasks[[1]]
@@ -92,30 +92,30 @@
       attr(,"n")
       [1] 1
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_model_tasks(create_model_task(task_ids = create_task_ids(create_task_id(
-        "origin_date", required = NULL, optional = c("2023-01-02", "2023-01-09",
-          "2023-01-16")), create_task_id("location", required = "US", optional = c(
-        "01", "02", "04", "05", "06")), create_task_id("target", required = NULL,
-        optional = c("inc death", "inc hosp")), create_task_id("horizon", required = 1L,
-        optional = 2:4)), output_type = create_output_type(create_output_type_mean(
-        is_required = TRUE, value_type = "double", value_minimum = 0L),
-      create_output_type_median(is_required = FALSE, value_type = "double"),
-      create_output_type_quantile(required = c(0.1, 0.2, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9),
-      is_required = TRUE, value_type = "double", value_minimum = 0)),
-      target_metadata = create_target_metadata(create_target_metadata_item(target_id = "inc hosp",
-        target_name = "Weekly incident influenza hospitalizations", target_units = "rate per 100,000 population",
-        target_keys = list(target = "inc hosp"), target_type = "discrete",
-        is_step_ahead = TRUE, time_unit = "week"), create_target_metadata_item(
-        target_id = "inc death", target_name = "Weekly incident influenza deaths",
-        target_units = "rate per 100,000 population", target_keys = list(target = "inc death"),
-        target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"))),
+      verify_latest_schema_version(create_model_tasks(create_model_task(task_ids = create_task_ids(
+        create_task_id("origin_date", required = NULL, optional = c("2023-01-02",
+          "2023-01-09", "2023-01-16")), create_task_id("location", required = "US",
+          optional = c("01", "02", "04", "05", "06")), create_task_id("target",
+          required = NULL, optional = c("inc death", "inc hosp")), create_task_id(
+          "horizon", required = 1L, optional = 2:4)), output_type = create_output_type(
+        create_output_type_mean(is_required = TRUE, value_type = "double",
+          value_minimum = 0L), create_output_type_median(is_required = FALSE,
+          value_type = "double"), create_output_type_quantile(required = c(0.1, 0.2,
+          0.3, 0.4, 0.6, 0.7, 0.8, 0.9), is_required = TRUE, value_type = "double",
+        value_minimum = 0)), target_metadata = create_target_metadata(
+        create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population", target_keys = list(target = "inc hosp"),
+          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"),
+        create_target_metadata_item(target_id = "inc death", target_name = "Weekly incident influenza deaths",
+          target_units = "rate per 100,000 population", target_keys = list(target = "inc death"),
+          target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"))),
       create_model_task(task_ids = create_task_ids(create_task_id("origin_date",
         required = NULL, optional = c("2023-01-02", "2023-01-09", "2023-01-16")),
       create_task_id("location", required = "US", optional = c("01", "02", "04", "05",
@@ -126,7 +126,7 @@
       target_metadata = create_target_metadata(create_target_metadata_item(target_id = "flu hosp rt chng",
         target_name = "Weekly influenza hospitalization rate change", target_units = "rate per 100,000 population",
         target_keys = list(target = "flu hosp rt chng"), target_type = "nominal",
-        is_step_ahead = TRUE, time_unit = "week"))))
+        is_step_ahead = TRUE, time_unit = "week")))))
     Output
       $model_tasks
       $model_tasks[[1]]
@@ -363,7 +363,7 @@
       attr(,"n")
       [1] 2
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/create_output_type.md
+++ b/tests/testthat/_snaps/create_output_type.md
@@ -1,11 +1,11 @@
 # create_output_type functions work correctly
 
     Code
-      create_output_type(create_output_type_mean(is_required = TRUE, value_type = "double",
-        value_minimum = 0L), create_output_type_median(is_required = FALSE,
-        value_type = "double"), create_output_type_quantile(required = c(0.1, 0.2,
-        0.3, 0.4, 0.6, 0.7, 0.8, 0.9), is_required = TRUE, value_type = "double",
-      value_minimum = 0))
+      verify_latest_schema_version(create_output_type(create_output_type_mean(
+        is_required = TRUE, value_type = "double", value_minimum = 0L),
+      create_output_type_median(is_required = FALSE, value_type = "double"),
+      create_output_type_quantile(required = c(0.1, 0.2, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9),
+      is_required = TRUE, value_type = "double", value_minimum = 0)))
     Output
       $output_type
       $output_type$mean
@@ -65,7 +65,7 @@
       attr(,"n")
       [1] 3
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/create_output_type_item.md
+++ b/tests/testthat/_snaps/create_output_type_item.md
@@ -326,9 +326,10 @@
 # create_output_type_sample works
 
     Code
-      create_output_type_sample(is_required = TRUE, output_type_id_type = "integer",
-        min_samples_per_task = 70L, max_samples_per_task = 100L, value_type = "double",
-        value_minimum = 0L, value_maximum = 1L)
+      verify_latest_schema_version(create_output_type_sample(is_required = TRUE,
+        output_type_id_type = "integer", min_samples_per_task = 70L,
+        max_samples_per_task = 100L, value_type = "double", value_minimum = 0L,
+        value_maximum = 1L))
     Output
       $sample
       $sample$output_type_id_params
@@ -360,7 +361,7 @@
       attr(,"class")
       [1] "output_type_item" "list"            
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
@@ -769,7 +770,7 @@
     Output
       old vs new
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 
 # schema version option works for create_output_type_quantile
 
@@ -779,7 +780,7 @@
     Output
       old vs new
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 
 # schema version option works for create_output_type_cdf
 
@@ -789,7 +790,7 @@
     Output
       old vs new
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 
 # schema version option works for create_output_type_pmf
 
@@ -799,7 +800,7 @@
     Output
       old vs new
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 
 # schema version option works for create_output_type_sample
 
@@ -809,5 +810,5 @@
     Output
       old vs new
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 

--- a/tests/testthat/_snaps/create_round.md
+++ b/tests/testthat/_snaps/create_round.md
@@ -1,9 +1,9 @@
 # create_round functions work correctly
 
     Code
-      create_round(round_id_from_variable = FALSE, round_id = "round_1", model_tasks = model_tasks,
-        submissions_due = list(start = "2023-01-12", end = "2023-01-18"),
-        last_data_date = "2023-01-02")
+      verify_latest_schema_version(create_round(round_id_from_variable = FALSE,
+        round_id = "round_1", model_tasks = model_tasks, submissions_due = list(
+          start = "2023-01-12", end = "2023-01-18"), last_data_date = "2023-01-02"))
     Output
       $round_id_from_variable
       [1] FALSE
@@ -102,16 +102,16 @@
       attr(,"round_id")
       [1] "round_1"
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_round(round_id_from_variable = TRUE, round_id = "origin_date",
-        model_tasks = model_tasks, submissions_due = list(relative_to = "origin_date",
-          start = -4L, end = 2L), last_data_date = "2023-01-02")
+      verify_latest_schema_version(create_round(round_id_from_variable = TRUE,
+        round_id = "origin_date", model_tasks = model_tasks, submissions_due = list(
+          relative_to = "origin_date", start = -4L, end = 2L), last_data_date = "2023-01-02"))
     Output
       $round_id_from_variable
       [1] TRUE
@@ -213,7 +213,7 @@
       attr(,"round_id")
       [1] "origin_date"
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/create_rounds.md
+++ b/tests/testthat/_snaps/create_rounds.md
@@ -1,9 +1,9 @@
 # create_rounds functions work correctly
 
     Code
-      create_rounds(create_round(round_id_from_variable = TRUE, round_id = "origin_date",
-        model_tasks = model_tasks, submissions_due = list(relative_to = "origin_date",
-          start = -4L, end = 2L)))
+      verify_latest_schema_version(create_rounds(create_round(round_id_from_variable = TRUE,
+        round_id = "origin_date", model_tasks = model_tasks, submissions_due = list(
+          relative_to = "origin_date", start = -4L, end = 2L))))
     Output
       $rounds
       $rounds[[1]]
@@ -106,23 +106,24 @@
       attr(,"n")
       [1] 1
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_rounds(create_round(round_id_from_variable = FALSE, round_id = "round_1",
-        model_tasks = create_model_tasks(create_model_task(task_ids = create_task_ids(
-          create_task_id("origin_date", required = NULL, optional = c("2023-01-09")),
-          create_task_id("location", required = "US", optional = c("01", "02", "04",
-            "05", "06")), create_task_id("horizon", required = 1L, optional = 2:4)),
-        output_type = create_output_type(create_output_type_mean(is_required = TRUE,
-          value_type = "double", value_minimum = 0L)), target_metadata = create_target_metadata(
-          create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
-            target_units = "rate per 100,000 population", target_keys = NULL,
-            target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))),
+      verify_latest_schema_version(create_rounds(create_round(round_id_from_variable = FALSE,
+        round_id = "round_1", model_tasks = create_model_tasks(create_model_task(
+          task_ids = create_task_ids(create_task_id("origin_date", required = NULL,
+            optional = c("2023-01-09")), create_task_id("location", required = "US",
+            optional = c("01", "02", "04", "05", "06")), create_task_id("horizon",
+            required = 1L, optional = 2:4)), output_type = create_output_type(
+            create_output_type_mean(is_required = TRUE, value_type = "double",
+              value_minimum = 0L)), target_metadata = create_target_metadata(
+            create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population", target_keys = NULL,
+              target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))),
         submissions_due = list(start = "2023-01-05", end = "2023-01-11"),
         last_data_date = "2023-01-06"), create_round(round_id_from_variable = FALSE,
         round_id = "round_2", model_tasks = create_model_tasks(create_model_task(
@@ -136,7 +137,7 @@
               target_units = "rate per 100,000 population", target_keys = NULL,
               target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))),
         submissions_due = list(start = "2023-01-12", end = "2023-01-18"),
-        last_data_date = "2023-01-13"))
+        last_data_date = "2023-01-13")))
     Output
       $rounds
       $rounds[[1]]
@@ -333,7 +334,7 @@
       attr(,"n")
       [1] 2
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/create_target_metadata.md
+++ b/tests/testthat/_snaps/create_target_metadata.md
@@ -1,13 +1,13 @@
 # create_target_metadata functions work correctly
 
     Code
-      create_target_metadata(create_target_metadata_item(target_id = "inc hosp",
-        target_name = "Weekly incident influenza hospitalizations", target_units = "rate per 100,000 population",
-        target_keys = list(target = "inc hosp"), target_type = "discrete",
-        is_step_ahead = TRUE, time_unit = "week"), create_target_metadata_item(
-        target_id = "inc death", target_name = "Weekly incident influenza deaths",
+      verify_latest_schema_version(create_target_metadata(create_target_metadata_item(
+        target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
+        target_units = "rate per 100,000 population", target_keys = list(target = "inc hosp"),
+        target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"),
+      create_target_metadata_item(target_id = "inc death", target_name = "Weekly incident influenza deaths",
         target_units = "rate per 100,000 population", target_keys = list(target = "inc death"),
-        target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"))
+        target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")))
     Output
       $target_metadata
       $target_metadata[[1]]
@@ -66,7 +66,7 @@
       attr(,"n")
       [1] 2
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/create_target_metadata_item.md
+++ b/tests/testthat/_snaps/create_target_metadata_item.md
@@ -1,9 +1,10 @@
 # create_target_metadata_item functions work correctly
 
     Code
-      create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
-        target_units = "rate per 100,000 population", target_keys = list(target = "inc hosp"),
-        target_type = "discrete", is_step_ahead = TRUE, time_unit = "week")
+      verify_latest_schema_version(create_target_metadata_item(target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations", target_units = "rate per 100,000 population",
+        target_keys = list(target = "inc hosp"), target_type = "discrete",
+        is_step_ahead = TRUE, time_unit = "week"))
     Output
       $target_id
       [1] "inc hosp"
@@ -31,16 +32,16 @@
       attr(,"class")
       [1] "target_metadata_item" "list"                
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_target_metadata_item(target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
-        target_units = "rate per 100,000 population", target_type = "discrete",
-        is_step_ahead = FALSE)
+      verify_latest_schema_version(create_target_metadata_item(target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations", target_units = "rate per 100,000 population",
+        target_type = "discrete", is_step_ahead = FALSE))
     Output
       $target_id
       [1] "inc hosp"
@@ -63,7 +64,7 @@
       attr(,"class")
       [1] "target_metadata_item" "list"                
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
@@ -160,7 +161,7 @@
     Output
       attr(old, 'schema_id') vs attr(new, 'schema_id')
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 
 # Target_keys of length more than 1 are not allowed post v5.0.0
 

--- a/tests/testthat/_snaps/create_task_id.md
+++ b/tests/testthat/_snaps/create_task_id.md
@@ -1,7 +1,8 @@
 # create_task_id works correctly
 
     Code
-      create_task_id("horizon", required = 1L, optional = 2:4)
+      verify_latest_schema_version(create_task_id("horizon", required = 1L, optional = 2:
+        4))
     Output
       $horizon
       $horizon$required
@@ -14,15 +15,15 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_task_id("origin_date", required = NULL, optional = c("2023-01-02",
-        "2023-01-09", "2023-01-16"))
+      verify_latest_schema_version(create_task_id("origin_date", required = NULL,
+        optional = c("2023-01-02", "2023-01-09", "2023-01-16")))
     Output
       $origin_date
       $origin_date$required
@@ -35,15 +36,15 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_task_id("scenario_id", required = NULL, optional = c("A-2021-03-28",
-        "B-2021-03-28"))
+      verify_latest_schema_version(create_task_id("scenario_id", required = NULL,
+        optional = c("A-2021-03-28", "B-2021-03-28")))
     Output
       $scenario_id
       $scenario_id$required
@@ -56,14 +57,15 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_task_id("scenario_id", required = NULL, optional = c(1L, 2L))
+      verify_latest_schema_version(create_task_id("scenario_id", required = NULL,
+        optional = c(1L, 2L)))
     Output
       $scenario_id
       $scenario_id$required
@@ -76,14 +78,15 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
 ---
 
     Code
-      create_task_id("horizon", required = NULL, optional = NULL)
+      verify_latest_schema_version(create_task_id("horizon", required = NULL,
+        optional = NULL))
     Output
       $horizon
       $horizon$required
@@ -96,7 +99,7 @@
       attr(,"class")
       [1] "task_id" "list"   
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 
@@ -139,5 +142,5 @@
     Output
       attr(old, 'schema_id') vs attr(new, 'schema_id')
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 

--- a/tests/testthat/_snaps/create_task_ids.md
+++ b/tests/testthat/_snaps/create_task_ids.md
@@ -1,12 +1,12 @@
 # create_task_ids functions work correctly
 
     Code
-      create_task_ids(create_task_id("origin_date", required = NULL, optional = c(
-        "2023-01-02", "2023-01-09", "2023-01-16")), create_task_id("scenario_id",
-        required = NULL, optional = c("A-2021-03-28", "B-2021-03-28")),
-      create_task_id("location", required = "US", optional = c("01", "02", "04", "05",
-        "06")), create_task_id("target", required = "inc hosp", optional = NULL),
-      create_task_id("horizon", required = 1L, optional = 2:4))
+      verify_latest_schema_version(create_task_ids(create_task_id("origin_date",
+        required = NULL, optional = c("2023-01-02", "2023-01-09", "2023-01-16")),
+      create_task_id("scenario_id", required = NULL, optional = c("A-2021-03-28",
+        "B-2021-03-28")), create_task_id("location", required = "US", optional = c(
+        "01", "02", "04", "05", "06")), create_task_id("target", required = "inc hosp",
+        optional = NULL), create_task_id("horizon", required = 1L, optional = 2:4)))
     Output
       $task_ids
       $task_ids$origin_date
@@ -55,7 +55,7 @@
       attr(,"n")
       [1] 5
       attr(,"schema_id")
-      [1] "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      [1] "latest"
       attr(,"branch")
       [1] "main"
 

--- a/tests/testthat/_snaps/download_tasks_schema.md
+++ b/tests/testthat/_snaps/download_tasks_schema.md
@@ -1,49 +1,7 @@
-# download_tasks_schema defaults work
-
-    Code
-      str(download_tasks_schema(), 4L)
-    Output
-      List of 8
-       $ $schema             : chr "https://json-schema.org/draft/2020-12/schema"
-       $ $id                 : chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
-       $ title               : chr "Schema for Modeling Hub model task definitions"
-       $ description         : chr "This is the schema of the tasks.json configuration file that defines the tasks within a modeling hub."
-       $ type                : chr "object"
-       $ properties          :List of 4
-        ..$ schema_version         :List of 4
-        .. ..$ description: chr "URL to a version of the Modeling Hub schema tasks-schema.json file (see https://github.com/hubverse-org/schemas"| __truncated__
-        .. ..$ examples   : chr "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.0/tasks-schema.json"
-        .. ..$ type       : chr "string"
-        .. ..$ format     : chr "uri"
-        ..$ rounds                 :List of 3
-        .. ..$ description: chr "Array of modeling round properties"
-        .. ..$ type       : chr "array"
-        .. ..$ items      :List of 5
-        .. .. ..$ type                : chr "object"
-        .. .. ..$ description         : chr "Individual modeling round properties"
-        .. .. ..$ properties          :List of 8
-        .. .. ..$ required            : chr [1:4] "round_id_from_variable" "round_id" "model_tasks" "submissions_due"
-        .. .. ..$ additionalProperties: logi TRUE
-        ..$ output_type_id_datatype:List of 5
-        .. ..$ description: chr "The hub level data type of the output_type_id column. This data type must be shared across all files in the hub"| __truncated__
-        .. ..$ default    : chr "auto"
-        .. ..$ examples   : chr "character"
-        .. ..$ type       : chr "string"
-        .. ..$ enum       : chr [1:6] "auto" "character" "double" "integer" ...
-        ..$ derived_task_ids       :List of 5
-        .. ..$ description: chr "Names of derived task IDs, i.e. task IDs whose values are derived from (and therefore dependent on) the values "| __truncated__
-        .. ..$ examples   : chr [1, 1] "target_end_date"
-        .. ..$ type       : chr [1:2] "array" "null"
-        .. ..$ uniqueItems: logi TRUE
-        .. ..$ items      :List of 1
-        .. .. ..$ type: chr "string"
-       $ required            : chr [1:2] "rounds" "schema_version"
-       $ additionalProperties: logi FALSE
-
 # download_tasks_schema json output work
 
     Code
-      download_tasks_schema(format = "json")
+      download_tasks_schema(schema_version = "v4.0.0", format = "json")
     Output
       {
           "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -1623,5 +1581,5 @@
     Output
       old vs new
       - "https://raw.githubusercontent.com/hubverse-org/schemas/main/v3.0.1/tasks-schema.json"
-      + "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json"
+      + "latest"
 

--- a/tests/testthat/helper-verify_latest_schema_version.R
+++ b/tests/testthat/helper-verify_latest_schema_version.R
@@ -1,0 +1,17 @@
+verify_latest_schema_version <- function(x) {
+  schema_id_version <- attr(x, "schema_id") |>
+    hubUtils::extract_schema_version()
+  latest_version <- hubUtils::get_schema_version_latest()
+  is_latest <- schema_id_version == latest_version
+  if (!is_latest) {
+    cli::cli_abort("{.var schema_id} version {.val {schema_id_version}} does not
+                       match expected latest version {.val {latest_version}}.")
+  }
+
+  attr(x, "schema_id") <- "latest"
+  if (!is.null(x$schema_version)) {
+    x$schema_version <- "latest"
+  }
+
+  return(x)
+}

--- a/tests/testthat/test-create_config.R
+++ b/tests/testthat/test-create_config.R
@@ -52,7 +52,7 @@ test_that("create_config functions work correctly", {
     )
   )
   expect_snapshot(
-    create_config(rounds)
+    create_config(rounds) |> verify_latest_schema_version()
   )
 })
 

--- a/tests/testthat/test-create_config.R
+++ b/tests/testthat/test-create_config.R
@@ -92,7 +92,6 @@ test_that("create_config handles output_type_id_datatype correctly ", {
 
 test_that("create_config derived_task_ids argument", {
   skip_if_offline()
-  # TODO: Remove branch specification when v4.0.0 released
   expect_snapshot(
     create_config(
       create_rounds(

--- a/tests/testthat/test-create_model_task.R
+++ b/tests/testthat/test-create_model_task.R
@@ -216,173 +216,175 @@ test_that("create_output_type_point functions error correctly", {
   withr::with_options(
     list(
       hubAdmin.schema_version = "v4.0.0"
-    ), {
-    task_ids <- create_task_ids(
-      create_task_id("origin_date",
-        required = NULL,
-        optional = c(
-          "2023-01-02",
-          "2023-01-09",
-          "2023-01-16"
+    ),
+    {
+      task_ids <- create_task_ids(
+        create_task_id("origin_date",
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
+        ),
+        create_task_id("target",
+          required = NULL,
+          optional = c("inc death", "inc hosp")
+        ),
+        create_task_id("horizon",
+          required = 1L,
+          optional = 2:4
         )
-      ),
-      create_task_id("target",
-        required = NULL,
-        optional = c("inc death", "inc hosp")
-      ),
-      create_task_id("horizon",
-        required = 1L,
-        optional = 2:4
       )
-    )
-    output_type <- create_output_type(
-      create_output_type_mean(
-        is_required = TRUE,
-        value_type = "double",
-        value_minimum = 0L
+      output_type <- create_output_type(
+        create_output_type_mean(
+          is_required = TRUE,
+          value_type = "double",
+          value_minimum = 0L
+        )
       )
-    )
-    expect_snapshot(
-      create_model_task(
-        task_ids = task_ids,
-        output_type = output_type,
-        target_metadata = create_target_metadata(
-          create_target_metadata_item(
-            target_id = "inc hosp",
-            target_name = "Weekly incident influenza hospitalizations",
-            target_units = "rate per 100,000 population",
-            target_keys = list(target = "inc hosp"),
-            target_type = "discrete",
-            is_step_ahead = TRUE,
-            time_unit = "week"
+      expect_snapshot(
+        create_model_task(
+          task_ids = task_ids,
+          output_type = output_type,
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = list(target = "inc hosp"),
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
           )
-        )
-      ),
-      error = TRUE
-    )
-    expect_snapshot(
-      create_model_task(
-        task_ids = task_ids,
-        output_type = output_type,
-        target_metadata = create_target_metadata(
-          create_target_metadata_item(
-            target_id = "inc hosp",
-            target_name = "Weekly incident influenza hospitalizations",
-            target_units = "rate per 100,000 population",
-            target_keys = list(targets = "inc hosp"),
-            target_type = "discrete",
-            is_step_ahead = TRUE,
-            time_unit = "week"
-          )
-        )
-      ),
-      error = TRUE
-    )
-
-    expect_snapshot(
-      create_model_task(
-        task_ids = task_ids,
-        output_type = list(a = 10),
-        target_metadata = create_target_metadata(
-          create_target_metadata_item(
-            target_id = "inc hosp",
-            target_name = "Weekly incident influenza hospitalizations",
-            target_units = "rate per 100,000 population",
-            target_keys = list(targets = "inc hosp"),
-            target_type = "discrete",
-            is_step_ahead = TRUE,
-            time_unit = "week"
-          )
-        )
-      ),
-      error = TRUE
-    )
-
-    task_ids <- create_task_ids(
-      create_task_id("origin_date",
-        required = NULL,
-        optional = c(
-          "2023-01-02",
-          "2023-01-09",
-          "2023-01-16"
-        )
-      ),
-      create_task_id("horizon",
-        required = 1L,
-        optional = 2:4
+        ),
+        error = TRUE
       )
-    )
-
-    attr(task_ids, "schema_id") <- "invalid_schema_id"
-    expect_snapshot(
-      create_model_task(
-        task_ids = task_ids,
-        output_type = output_type,
-        target_metadata = create_target_metadata(
-          create_target_metadata_item(
-            target_id = "inc hosp",
-            target_name = "Weekly incident influenza hospitalizations",
-            target_units = "rate per 100,000 population",
-            target_keys = NULL,
-            target_type = "discrete",
-            is_step_ahead = TRUE,
-            time_unit = "week"
+      expect_snapshot(
+        create_model_task(
+          task_ids = task_ids,
+          output_type = output_type,
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = list(targets = "inc hosp"),
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
           )
-        )
-      ),
-      error = TRUE
-    )
+        ),
+        error = TRUE
+      )
 
-    expect_snapshot(
-      create_model_task(
-        task_ids = create_task_ids(
-          create_task_id("origin_date",
-            required = NULL,
-            optional = c(
-              "2023-01-02",
-              "2023-01-09",
-              "2023-01-16"
+      expect_snapshot(
+        create_model_task(
+          task_ids = task_ids,
+          output_type = list(a = 10),
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = list(targets = "inc hosp"),
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
+          )
+        ),
+        error = TRUE
+      )
+
+      task_ids <- create_task_ids(
+        create_task_id("origin_date",
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
+        ),
+        create_task_id("horizon",
+          required = 1L,
+          optional = 2:4
+        )
+      )
+
+      attr(task_ids, "schema_id") <- "invalid_schema_id"
+      expect_snapshot(
+        create_model_task(
+          task_ids = task_ids,
+          output_type = output_type,
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = NULL,
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
+          )
+        ),
+        error = TRUE
+      )
+
+      expect_snapshot(
+        create_model_task(
+          task_ids = create_task_ids(
+            create_task_id("origin_date",
+              required = NULL,
+              optional = c(
+                "2023-01-02",
+                "2023-01-09",
+                "2023-01-16"
+              )
+            ),
+            create_task_id("location",
+              required = "US",
+              optional = c("01", "02", "04", "05", "06")
+            ),
+            create_task_id("horizon",
+              required = 1L,
+              optional = 2:4
             )
           ),
-          create_task_id("location",
-            required = "US",
-            optional = c("01", "02", "04", "05", "06")
+          output_type = create_output_type(
+            create_output_type_mean(
+              is_required = TRUE,
+              value_type = "double",
+              value_minimum = 0L
+            ),
+            create_output_type_sample(
+              is_required = FALSE,
+              output_type_id_type = "character",
+              max_length = 5L,
+              min_samples_per_task = 70L, max_samples_per_task = 100L,
+              compound_taskid_set = c("horizon", "random_task_id"),
+              value_type = "double",
+              value_minimum = 0L,
+              value_maximum = 1L
+            )
           ),
-          create_task_id("horizon",
-            required = 1L,
-            optional = 2:4
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = NULL,
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
           )
         ),
-        output_type = create_output_type(
-          create_output_type_mean(
-            is_required = TRUE,
-            value_type = "double",
-            value_minimum = 0L
-          ),
-          create_output_type_sample(
-            is_required = FALSE,
-            output_type_id_type = "character",
-            max_length = 5L,
-            min_samples_per_task = 70L, max_samples_per_task = 100L,
-            compound_taskid_set = c("horizon", "random_task_id"),
-            value_type = "double",
-            value_minimum = 0L,
-            value_maximum = 1L
-          )
-        ),
-        target_metadata = create_target_metadata(
-          create_target_metadata_item(
-            target_id = "inc hosp",
-            target_name = "Weekly incident influenza hospitalizations",
-            target_units = "rate per 100,000 population",
-            target_keys = NULL,
-            target_type = "discrete",
-            is_step_ahead = TRUE,
-            time_unit = "week"
-          )
-        )
-      ),
-      error = TRUE
-    )
-  })
+        error = TRUE
+      )
+    }
+  )
 })

--- a/tests/testthat/test-create_model_task.R
+++ b/tests/testthat/test-create_model_task.R
@@ -89,7 +89,7 @@ test_that("create_model_task functions work correctly", {
           time_unit = "week"
         )
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 
   expect_snapshot(
@@ -140,7 +140,7 @@ test_that("create_model_task functions work correctly", {
           time_unit = "week"
         )
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 
   expect_snapshot(
@@ -207,177 +207,182 @@ test_that("create_model_task functions work correctly", {
           time_unit = "week"
         )
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 
 test_that("create_output_type_point functions error correctly", {
   skip_if_offline()
-  task_ids <- create_task_ids(
-    create_task_id("origin_date",
-      required = NULL,
-      optional = c(
-        "2023-01-02",
-        "2023-01-09",
-        "2023-01-16"
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v4.0.0"
+    ), {
+    task_ids <- create_task_ids(
+      create_task_id("origin_date",
+        required = NULL,
+        optional = c(
+          "2023-01-02",
+          "2023-01-09",
+          "2023-01-16"
+        )
+      ),
+      create_task_id("target",
+        required = NULL,
+        optional = c("inc death", "inc hosp")
+      ),
+      create_task_id("horizon",
+        required = 1L,
+        optional = 2:4
       )
-    ),
-    create_task_id("target",
-      required = NULL,
-      optional = c("inc death", "inc hosp")
-    ),
-    create_task_id("horizon",
-      required = 1L,
-      optional = 2:4
     )
-  )
-  output_type <- create_output_type(
-    create_output_type_mean(
-      is_required = TRUE,
-      value_type = "double",
-      value_minimum = 0L
+    output_type <- create_output_type(
+      create_output_type_mean(
+        is_required = TRUE,
+        value_type = "double",
+        value_minimum = 0L
+      )
     )
-  )
-  expect_snapshot(
-    create_model_task(
-      task_ids = task_ids,
-      output_type = output_type,
-      target_metadata = create_target_metadata(
-        create_target_metadata_item(
-          target_id = "inc hosp",
-          target_name = "Weekly incident influenza hospitalizations",
-          target_units = "rate per 100,000 population",
-          target_keys = list(target = "inc hosp"),
-          target_type = "discrete",
-          is_step_ahead = TRUE,
-          time_unit = "week"
+    expect_snapshot(
+      create_model_task(
+        task_ids = task_ids,
+        output_type = output_type,
+        target_metadata = create_target_metadata(
+          create_target_metadata_item(
+            target_id = "inc hosp",
+            target_name = "Weekly incident influenza hospitalizations",
+            target_units = "rate per 100,000 population",
+            target_keys = list(target = "inc hosp"),
+            target_type = "discrete",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          )
         )
-      )
-    ),
-    error = TRUE
-  )
-  expect_snapshot(
-    create_model_task(
-      task_ids = task_ids,
-      output_type = output_type,
-      target_metadata = create_target_metadata(
-        create_target_metadata_item(
-          target_id = "inc hosp",
-          target_name = "Weekly incident influenza hospitalizations",
-          target_units = "rate per 100,000 population",
-          target_keys = list(targets = "inc hosp"),
-          target_type = "discrete",
-          is_step_ahead = TRUE,
-          time_unit = "week"
-        )
-      )
-    ),
-    error = TRUE
-  )
-
-  expect_snapshot(
-    create_model_task(
-      task_ids = task_ids,
-      output_type = list(a = 10),
-      target_metadata = create_target_metadata(
-        create_target_metadata_item(
-          target_id = "inc hosp",
-          target_name = "Weekly incident influenza hospitalizations",
-          target_units = "rate per 100,000 population",
-          target_keys = list(targets = "inc hosp"),
-          target_type = "discrete",
-          is_step_ahead = TRUE,
-          time_unit = "week"
-        )
-      )
-    ),
-    error = TRUE
-  )
-
-  task_ids <- create_task_ids(
-    create_task_id("origin_date",
-      required = NULL,
-      optional = c(
-        "2023-01-02",
-        "2023-01-09",
-        "2023-01-16"
-      )
-    ),
-    create_task_id("horizon",
-      required = 1L,
-      optional = 2:4
+      ),
+      error = TRUE
     )
-  )
-
-  attr(task_ids, "schema_id") <- "invalid_schema_id"
-  expect_snapshot(
-    create_model_task(
-      task_ids = task_ids,
-      output_type = output_type,
-      target_metadata = create_target_metadata(
-        create_target_metadata_item(
-          target_id = "inc hosp",
-          target_name = "Weekly incident influenza hospitalizations",
-          target_units = "rate per 100,000 population",
-          target_keys = NULL,
-          target_type = "discrete",
-          is_step_ahead = TRUE,
-          time_unit = "week"
+    expect_snapshot(
+      create_model_task(
+        task_ids = task_ids,
+        output_type = output_type,
+        target_metadata = create_target_metadata(
+          create_target_metadata_item(
+            target_id = "inc hosp",
+            target_name = "Weekly incident influenza hospitalizations",
+            target_units = "rate per 100,000 population",
+            target_keys = list(targets = "inc hosp"),
+            target_type = "discrete",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          )
         )
-      )
-    ),
-    error = TRUE
-  )
+      ),
+      error = TRUE
+    )
 
-  expect_snapshot(
-    create_model_task(
-      task_ids = create_task_ids(
-        create_task_id("origin_date",
-          required = NULL,
-          optional = c(
-            "2023-01-02",
-            "2023-01-09",
-            "2023-01-16"
+    expect_snapshot(
+      create_model_task(
+        task_ids = task_ids,
+        output_type = list(a = 10),
+        target_metadata = create_target_metadata(
+          create_target_metadata_item(
+            target_id = "inc hosp",
+            target_name = "Weekly incident influenza hospitalizations",
+            target_units = "rate per 100,000 population",
+            target_keys = list(targets = "inc hosp"),
+            target_type = "discrete",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          )
+        )
+      ),
+      error = TRUE
+    )
+
+    task_ids <- create_task_ids(
+      create_task_id("origin_date",
+        required = NULL,
+        optional = c(
+          "2023-01-02",
+          "2023-01-09",
+          "2023-01-16"
+        )
+      ),
+      create_task_id("horizon",
+        required = 1L,
+        optional = 2:4
+      )
+    )
+
+    attr(task_ids, "schema_id") <- "invalid_schema_id"
+    expect_snapshot(
+      create_model_task(
+        task_ids = task_ids,
+        output_type = output_type,
+        target_metadata = create_target_metadata(
+          create_target_metadata_item(
+            target_id = "inc hosp",
+            target_name = "Weekly incident influenza hospitalizations",
+            target_units = "rate per 100,000 population",
+            target_keys = NULL,
+            target_type = "discrete",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          )
+        )
+      ),
+      error = TRUE
+    )
+
+    expect_snapshot(
+      create_model_task(
+        task_ids = create_task_ids(
+          create_task_id("origin_date",
+            required = NULL,
+            optional = c(
+              "2023-01-02",
+              "2023-01-09",
+              "2023-01-16"
+            )
+          ),
+          create_task_id("location",
+            required = "US",
+            optional = c("01", "02", "04", "05", "06")
+          ),
+          create_task_id("horizon",
+            required = 1L,
+            optional = 2:4
           )
         ),
-        create_task_id("location",
-          required = "US",
-          optional = c("01", "02", "04", "05", "06")
+        output_type = create_output_type(
+          create_output_type_mean(
+            is_required = TRUE,
+            value_type = "double",
+            value_minimum = 0L
+          ),
+          create_output_type_sample(
+            is_required = FALSE,
+            output_type_id_type = "character",
+            max_length = 5L,
+            min_samples_per_task = 70L, max_samples_per_task = 100L,
+            compound_taskid_set = c("horizon", "random_task_id"),
+            value_type = "double",
+            value_minimum = 0L,
+            value_maximum = 1L
+          )
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
+        target_metadata = create_target_metadata(
+          create_target_metadata_item(
+            target_id = "inc hosp",
+            target_name = "Weekly incident influenza hospitalizations",
+            target_units = "rate per 100,000 population",
+            target_keys = NULL,
+            target_type = "discrete",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          )
         )
       ),
-      output_type = create_output_type(
-        create_output_type_mean(
-          is_required = TRUE,
-          value_type = "double",
-          value_minimum = 0L
-        ),
-        create_output_type_sample(
-          is_required = FALSE,
-          output_type_id_type = "character",
-          max_length = 5L,
-          min_samples_per_task = 70L, max_samples_per_task = 100L,
-          compound_taskid_set = c("horizon", "random_task_id"),
-          value_type = "double",
-          value_minimum = 0L,
-          value_maximum = 1L
-        )
-      ),
-      target_metadata = create_target_metadata(
-        create_target_metadata_item(
-          target_id = "inc hosp",
-          target_name = "Weekly incident influenza hospitalizations",
-          target_units = "rate per 100,000 population",
-          target_keys = NULL,
-          target_type = "discrete",
-          is_step_ahead = TRUE,
-          time_unit = "week"
-        )
-      )
-    ),
-    error = TRUE
-  )
+      error = TRUE
+    )
+  })
 })

--- a/tests/testthat/test-create_model_tasks.R
+++ b/tests/testthat/test-create_model_tasks.R
@@ -40,7 +40,7 @@ test_that("create_model_tasks functions work correctly", {
           )
         )
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 
   expect_snapshot(
@@ -157,7 +157,7 @@ test_that("create_model_tasks functions work correctly", {
           )
         )
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 
@@ -165,83 +165,12 @@ test_that("create_model_tasks functions work correctly", {
 
 test_that("create_model_tasks functions error correctly", {
   skip_if_offline()
-  model_task_1 <- create_model_task(
-    task_ids = create_task_ids(
-      create_task_id("origin_date",
-        required = NULL,
-        optional = c(
-          "2023-01-02",
-          "2023-01-09",
-          "2023-01-16"
-        )
-      ),
-      create_task_id("location",
-        required = "US",
-        optional = c("01", "02", "04", "05", "06")
-      ),
-      create_task_id("target",
-        required = NULL,
-        optional = c("inc death", "inc hosp")
-      ),
-      create_task_id("horizon",
-        required = 1L,
-        optional = 2:4
-      )
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v4.0.0"
     ),
-    output_type = create_output_type(
-      create_output_type_mean(
-        is_required = TRUE,
-        value_type = "double",
-        value_minimum = 0L
-      ),
-      create_output_type_median(
-        is_required = FALSE,
-        value_type = "double"
-      ),
-      create_output_type_quantile(
-        required = c(
-          0.1, 0.2, 0.3, 0.4, 0.6,
-          0.7, 0.8, 0.9
-        ),
-        is_required = TRUE,
-        value_type = "double",
-        value_minimum = 0
-      )
-    ),
-    target_metadata = create_target_metadata(
-      create_target_metadata_item(
-        target_id = "inc hosp",
-        target_name = "Weekly incident influenza hospitalizations",
-        target_units = "rate per 100,000 population",
-        target_keys = list(target = "inc hosp"),
-        target_type = "discrete",
-        is_step_ahead = TRUE,
-        time_unit = "week"
-      ),
-      create_target_metadata_item(
-        target_id = "inc death",
-        target_name = "Weekly incident influenza deaths",
-        target_units = "rate per 100,000 population",
-        target_keys = list(target = "inc death"),
-        target_type = "discrete",
-        is_step_ahead = TRUE,
-        time_unit = "week"
-      )
-    )
-  )
-  expect_snapshot(
-    create_model_tasks(
-      model_task_1,
-      list(a = 10)
-    ),
-    error = TRUE
-  )
-
-  attr(model_task_1, "schema_id") <- "invalid_schema_id"
-  expect_snapshot(
-    create_model_tasks(
-      model_task_1,
-      create_model_task(
+    {
+      model_task_1 <- create_model_task(
         task_ids = create_task_ids(
           create_task_id("origin_date",
             required = NULL,
@@ -256,8 +185,8 @@ test_that("create_model_tasks functions error correctly", {
             optional = c("01", "02", "04", "05", "06")
           ),
           create_task_id("target",
-            required = "flu hosp rt chng",
-            optional = NULL
+            required = NULL,
+            optional = c("inc death", "inc hosp")
           ),
           create_task_id("horizon",
             required = 1L,
@@ -265,31 +194,109 @@ test_that("create_model_tasks functions error correctly", {
           )
         ),
         output_type = create_output_type(
-          create_output_type_pmf(
+          create_output_type_mean(
+            is_required = TRUE,
+            value_type = "double",
+            value_minimum = 0L
+          ),
+          create_output_type_median(
+            is_required = FALSE,
+            value_type = "double"
+          ),
+          create_output_type_quantile(
             required = c(
-              "large_decrease",
-              "decrease",
-              "stable",
-              "increase",
-              "large_increase"
+              0.1, 0.2, 0.3, 0.4, 0.6,
+              0.7, 0.8, 0.9
             ),
             is_required = TRUE,
-            value_type = "double"
+            value_type = "double",
+            value_minimum = 0
           )
         ),
         target_metadata = create_target_metadata(
           create_target_metadata_item(
-            target_id = "flu hosp rt chng",
-            target_name = "Weekly influenza hospitalization rate change",
+            target_id = "inc hosp",
+            target_name = "Weekly incident influenza hospitalizations",
             target_units = "rate per 100,000 population",
-            target_keys = list(target = "flu hosp rt chng"),
-            target_type = "nominal",
+            target_keys = list(target = "inc hosp"),
+            target_type = "discrete",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          ),
+          create_target_metadata_item(
+            target_id = "inc death",
+            target_name = "Weekly incident influenza deaths",
+            target_units = "rate per 100,000 population",
+            target_keys = list(target = "inc death"),
+            target_type = "discrete",
             is_step_ahead = TRUE,
             time_unit = "week"
           )
         )
       )
-    ),
-    error = TRUE
+      expect_snapshot(
+        create_model_tasks(
+          model_task_1,
+          list(a = 10)
+        ),
+        error = TRUE
+      )
+
+      attr(model_task_1, "schema_id") <- "invalid_schema_id"
+      expect_snapshot(
+        create_model_tasks(
+          model_task_1,
+          create_model_task(
+            task_ids = create_task_ids(
+              create_task_id("origin_date",
+                required = NULL,
+                optional = c(
+                  "2023-01-02",
+                  "2023-01-09",
+                  "2023-01-16"
+                )
+              ),
+              create_task_id("location",
+                required = "US",
+                optional = c("01", "02", "04", "05", "06")
+              ),
+              create_task_id("target",
+                required = "flu hosp rt chng",
+                optional = NULL
+              ),
+              create_task_id("horizon",
+                required = 1L,
+                optional = 2:4
+              )
+            ),
+            output_type = create_output_type(
+              create_output_type_pmf(
+                required = c(
+                  "large_decrease",
+                  "decrease",
+                  "stable",
+                  "increase",
+                  "large_increase"
+                ),
+                is_required = TRUE,
+                value_type = "double"
+              )
+            ),
+            target_metadata = create_target_metadata(
+              create_target_metadata_item(
+                target_id = "flu hosp rt chng",
+                target_name = "Weekly influenza hospitalization rate change",
+                target_units = "rate per 100,000 population",
+                target_keys = list(target = "flu hosp rt chng"),
+                target_type = "nominal",
+                is_step_ahead = TRUE,
+                time_unit = "week"
+              )
+            )
+          )
+        ),
+        error = TRUE
+      )
+    }
   )
 })

--- a/tests/testthat/test-create_output_type.R
+++ b/tests/testthat/test-create_output_type.R
@@ -20,7 +20,7 @@ test_that("create_output_type functions work correctly", {
         value_type = "double",
         value_minimum = 0
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 

--- a/tests/testthat/test-create_output_type_item.R
+++ b/tests/testthat/test-create_output_type_item.R
@@ -163,7 +163,7 @@ test_that("create_output_type_sample works", {
       value_type = "double",
       value_minimum = 0L,
       value_maximum = 1L
-    )
+    ) |> verify_latest_schema_version()
   )
   expect_snapshot(
     create_output_type_sample(
@@ -439,7 +439,7 @@ test_that("schema version option works for create_output_type_mean", {
     is_required = TRUE,
     value_type = "double",
     value_minimum = 0L
-  )
+  ) |> verify_latest_schema_version()
 
   arg_version <- create_output_type_mean(
     is_required = TRUE,
@@ -476,7 +476,7 @@ test_that("schema version option works for create_output_type_quantile", {
     is_required = FALSE,
     value_type = "double",
     value_minimum = 0
-  )
+  ) |> verify_latest_schema_version()
 
   arg_version <- create_output_type_quantile(
     required = c(0.25, 0.5, 0.75),
@@ -525,7 +525,7 @@ test_that("schema version option works for create_output_type_cdf", {
       ),
       is_required = FALSE,
       value_type = "double"
-    )
+    ) |> verify_latest_schema_version()
 
   arg_version <-
     create_output_type_cdf(
@@ -574,7 +574,7 @@ test_that("schema version option works for create_output_type_pmf", {
     ),
     is_required = FALSE,
     value_type = "double"
-  )
+  ) |> verify_latest_schema_version()
 
   arg_version <- create_output_type_pmf(
     required = NULL,
@@ -620,7 +620,8 @@ test_that("schema version option works for create_output_type_sample", {
     value_type = "double",
     value_minimum = 0L,
     value_maximum = 1L
-  )
+  ) |> verify_latest_schema_version()
+
   arg_version <- create_output_type_sample(
     is_required = FALSE,
     output_type_id_type = "character",

--- a/tests/testthat/test-create_output_type_item.R
+++ b/tests/testthat/test-create_output_type_item.R
@@ -193,7 +193,6 @@ test_that("create_output_type_sample works", {
 
 test_that("create_output_type_sample errors correctly", {
   skip_if_offline()
-  # TODO: Remove branches when v4.0.0 is released
   # v4 type fails correctly
   expect_error(
     create_output_type_sample(
@@ -304,7 +303,6 @@ test_that("create_output_type_item is back-compatible", {
 
 test_that("create_output_type_item works with v4 schema", {
   skip_if_offline()
-  # TODO: Remove branch argument when v4.0.0 is released
   expect_snapshot(
     create_output_type_mean(
       is_required = TRUE,
@@ -333,8 +331,6 @@ test_that("create_output_type_item works with v4 schema", {
 
 test_that("create_output_type_dist fns support v4 schema", {
   skip_if_offline()
-  # TODO: Remove branch argument when v4.0.0 is released
-
   expect_snapshot(
     create_output_type_quantile(
       required = c(0.25, 0.5, 0.75),

--- a/tests/testthat/test-create_round.R
+++ b/tests/testthat/test-create_round.R
@@ -229,8 +229,7 @@ test_that("validating round_id patterns when round_id_from_var = TRUE works", {
   skip_if_offline()
   withr::with_options(
     list(
-      hubAdmin.schema_version = "v5.0.0",
-      hubAdmin.branch = "br-v5.0.0"
+      hubAdmin.schema_version = "v5.0.0"
     ),
     {
       output_types <- create_output_type(
@@ -372,8 +371,7 @@ test_that("validating round_id pattern when round_id_from_var = FALSE works", {
   skip_if_offline()
   withr::with_options(
     list(
-      hubAdmin.schema_version = "v5.0.0",
-      hubAdmin.branch = "br-v5.0.0"
+      hubAdmin.schema_version = "v5.0.0"
     ),
     {
       output_types <- create_output_type(

--- a/tests/testthat/test-create_round.R
+++ b/tests/testthat/test-create_round.R
@@ -50,7 +50,7 @@ test_that("create_round functions work correctly", {
         end = "2023-01-18"
       ),
       last_data_date = "2023-01-02"
-    )
+    ) |> verify_latest_schema_version()
   )
   expect_snapshot(
     create_round(
@@ -63,7 +63,7 @@ test_that("create_round functions work correctly", {
         end = 2L
       ),
       last_data_date = "2023-01-02"
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 

--- a/tests/testthat/test-create_rounds.R
+++ b/tests/testthat/test-create_rounds.R
@@ -52,7 +52,7 @@ test_that("create_rounds functions work correctly", {
           end = 2L
         )
       )
-    )
+    ) |> verify_latest_schema_version()
   )
   expect_snapshot(
     create_rounds(
@@ -152,7 +152,7 @@ test_that("create_rounds functions work correctly", {
         ),
         last_data_date = "2023-01-13"
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 

--- a/tests/testthat/test-create_target_metadata.R
+++ b/tests/testthat/test-create_target_metadata.R
@@ -20,7 +20,7 @@ test_that("create_target_metadata functions work correctly", {
         is_step_ahead = TRUE,
         time_unit = "week"
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 
@@ -90,29 +90,37 @@ test_that("create_target_metadata functions error correctly", {
     error = TRUE
   )
 
-  item_1 <- create_target_metadata_item(
-    target_id = "inc hosp",
-    target_name = "Weekly incident influenza hospitalizations",
-    target_units = "rate per 100,000 population",
-    target_keys = list(target = "inc hosp"),
-    target_type = "discrete",
-    is_step_ahead = TRUE,
-    time_unit = "week"
-  )
-  attr(item_1, "schema_id") <- "invalid_schema"
-  expect_snapshot(
-    create_target_metadata(
-      item_1,
-      create_target_metadata_item(
-        target_id = "inc death",
-        target_name = "Weekly incident influenza deaths",
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v4.0.0",
+      hubAdmin.branch = "main"
+    ),
+    {
+      item_1 <- create_target_metadata_item(
+        target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations",
         target_units = "rate per 100,000 population",
         target_keys = list(target = "inc hosp"),
         target_type = "discrete",
         is_step_ahead = TRUE,
         time_unit = "week"
       )
-    ),
-    error = TRUE
+      attr(item_1, "schema_id") <- "invalid_schema"
+      expect_snapshot(
+        create_target_metadata(
+          item_1,
+          create_target_metadata_item(
+            target_id = "inc death",
+            target_name = "Weekly incident influenza deaths",
+            target_units = "rate per 100,000 population",
+            target_keys = list(target = "inc hosp"),
+            target_type = "discrete",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          )
+        ),
+        error = TRUE
+      )
+    }
   )
 })

--- a/tests/testthat/test-create_target_metadata_item.R
+++ b/tests/testthat/test-create_target_metadata_item.R
@@ -9,7 +9,7 @@ test_that("create_target_metadata_item functions work correctly", {
       target_type = "discrete",
       is_step_ahead = TRUE,
       time_unit = "week"
-    )
+    ) |> verify_latest_schema_version()
   )
   expect_snapshot(
     create_target_metadata_item(
@@ -18,7 +18,7 @@ test_that("create_target_metadata_item functions work correctly", {
       target_units = "rate per 100,000 population",
       target_type = "discrete",
       is_step_ahead = FALSE
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 
@@ -114,7 +114,7 @@ test_that("schema version option works for create_target_metadata_item", {
     target_type = "discrete",
     is_step_ahead = TRUE,
     time_unit = "week"
-  )
+  ) |> verify_latest_schema_version()
 
   arg_version <- create_target_metadata_item(
     target_id = "inc hosp",
@@ -153,9 +153,7 @@ test_that("Target_keys of length more than 1 are not allowed post v5.0.0", {
   skip_if_offline()
   withr::with_options(
     list(
-      hubAdmin.schema_version = "v5.0.0",
-      # TDOD: remove branch argument when v5.0.0 is released.
-      hubAdmin.branch = "br-v5.0.0"
+      hubAdmin.schema_version = "v5.0.0"
     ),
     {
       # One target_key is allowed in v5.0.0 and later versions.

--- a/tests/testthat/test-create_task_id.R
+++ b/tests/testthat/test-create_task_id.R
@@ -1,37 +1,47 @@
 test_that("create_task_id works correctly", {
   skip_if_offline()
-  expect_snapshot(create_task_id("horizon",
-    required = 1L,
-    optional = 2:4
-  ))
+  expect_snapshot(
+    create_task_id("horizon",
+      required = 1L,
+      optional = 2:4
+    ) |> verify_latest_schema_version()
+  )
 
-  expect_snapshot(create_task_id("origin_date",
-    required = NULL,
-    optional = c(
-      "2023-01-02",
-      "2023-01-09",
-      "2023-01-16"
-    )
-  ))
-  expect_snapshot(create_task_id("scenario_id",
-    required = NULL,
-    optional = c(
-      "A-2021-03-28",
-      "B-2021-03-28"
-    )
-  ))
-  expect_snapshot(create_task_id("scenario_id",
-    required = NULL,
-    optional = c(
-      1L,
-      2L
-    )
-  ))
+  expect_snapshot(
+    create_task_id("origin_date",
+      required = NULL,
+      optional = c(
+        "2023-01-02",
+        "2023-01-09",
+        "2023-01-16"
+      )
+    ) |> verify_latest_schema_version()
+  )
+
+  expect_snapshot(
+    create_task_id("scenario_id",
+      required = NULL,
+      optional = c(
+        "A-2021-03-28",
+        "B-2021-03-28"
+      )
+    ) |> verify_latest_schema_version()
+  )
+
+  expect_snapshot(
+    create_task_id("scenario_id",
+      required = NULL,
+      optional = c(
+        1L,
+        2L
+      )
+    ) |> verify_latest_schema_version()
+  )
   expect_snapshot(
     create_task_id("horizon",
       required = NULL,
       optional = NULL
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 
@@ -102,7 +112,7 @@ test_that("schema version option works for create_task_id", {
   version_default <- create_task_id("horizon",
     required = 1L,
     optional = 2:4
-  )
+  ) |> verify_latest_schema_version()
 
   arg_version <- create_task_id("horizon",
     required = 1L,

--- a/tests/testthat/test-create_task_ids.R
+++ b/tests/testthat/test-create_task_ids.R
@@ -29,7 +29,7 @@ test_that("create_task_ids functions work correctly", {
         required = 1L,
         optional = 2:4
       )
-    )
+    ) |> verify_latest_schema_version()
   )
 })
 
@@ -74,26 +74,34 @@ test_that("create_task_ids functions error correctly", {
     error = TRUE
   )
 
-  item_1 <- create_task_id("origin_date",
-    required = NULL,
-    optional = c(
-      "2023-01-02",
-      "2023-01-09",
-      "2023-01-16"
-    )
-  )
-  attr(item_1, "schema_id") <- "invalid_schema"
-  expect_snapshot(
-    create_task_ids(
-      item_1,
-      create_task_id("scenario_id",
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v4.0.0",
+      hubAdmin.branch = "main"
+    ),
+    {
+      item_1 <- create_task_id("origin_date",
         required = NULL,
         optional = c(
-          "A-2021-03-28",
-          "B-2021-03-28"
+          "2023-01-02",
+          "2023-01-09",
+          "2023-01-16"
         )
       )
-    ),
-    error = TRUE
+      attr(item_1, "schema_id") <- "invalid_schema"
+      expect_snapshot(
+        create_task_ids(
+          item_1,
+          create_task_id("scenario_id",
+            required = NULL,
+            optional = c(
+              "A-2021-03-28",
+              "B-2021-03-28"
+            )
+          )
+        ),
+        error = TRUE
+      )
+    }
   )
 })

--- a/tests/testthat/test-download_tasks_schema.R
+++ b/tests/testthat/test-download_tasks_schema.R
@@ -1,14 +1,26 @@
 test_that("download_tasks_schema defaults work", {
   skip_if_offline()
-  expect_snapshot(
-    str(download_tasks_schema(), 4L)
+  latest_schema <- download_tasks_schema()
+  schema_id_version <- latest_schema$`$id` |>
+    hubUtils::extract_schema_version()
+  expect_equal(schema_id_version, hubUtils::get_schema_version_latest())
+
+  expect_equal(
+    names(latest_schema),
+    c(
+      "$schema", "$id", "title", "description", "type", "properties",
+      "required", "additionalProperties"
+    )
   )
 })
 
 test_that("download_tasks_schema json output work", {
   skip_if_offline()
   expect_snapshot(
-    download_tasks_schema(format = "json")
+    download_tasks_schema(
+      schema_version = "v4.0.0",
+      format = "json"
+    )
   )
 })
 
@@ -32,6 +44,7 @@ test_that("download_tasks_schema schema version work", {
 test_that("schema version option works for download_tasks_schema", {
   skip_if_offline()
   version_default <- download_tasks_schema()
+  version_default$`$id` <- "latest"
 
   arg_version <- download_tasks_schema(
     schema_version = "v3.0.1",
@@ -39,8 +52,10 @@ test_that("schema version option works for download_tasks_schema", {
   )
 
   withr::with_options(
-    list(hubAdmin.schema_version = "v3.0.1",
-         hubAdmin.branch = "main"),
+    list(
+      hubAdmin.schema_version = "v3.0.1",
+      hubAdmin.branch = "main"
+    ),
     {
       opt_version <- download_tasks_schema()
     }

--- a/tests/testthat/test-get_error_path.R
+++ b/tests/testthat/test-get_error_path.R
@@ -22,7 +22,7 @@ test_that("Creating schema paths works correctly", {
   )
   # Test that custom_task_id returns task_ids/additionalProperties schema path with version >= v2.0.0
   schema <- hubUtils::get_schema(
-    "https://raw.githubusercontent.com/hubverse-org/schemas/br-v2.0.0/v2.0.0/tasks-schema.json"
+    "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json"
   )
   expect_equal(
     get_error_path(schema, "custom_task_id", "schema"),

--- a/tests/testthat/test-schema_autobox.R
+++ b/tests/testthat/test-schema_autobox.R
@@ -1,132 +1,140 @@
 test_that("schema autobox boxes length 1L vectors correctly", {
   skip_if_offline()
-  config <- create_config(
-    create_rounds(
-      create_round(
-        round_id_from_variable = TRUE,
-        round_id = "origin_date",
-        model_tasks = create_model_tasks(
-          create_model_task(
-            task_ids = create_task_ids(
-              create_task_id("origin_date",
-                required = NULL,
-                optional = c(
-                  "2023-01-02",
-                  "2023-01-09",
-                  "2023-01-16"
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v4.0.0",
+      hubAdmin.branch = "main"
+    ),
+    {
+      config <- create_config(
+        create_rounds(
+          create_round(
+            round_id_from_variable = TRUE,
+            round_id = "origin_date",
+            model_tasks = create_model_tasks(
+              create_model_task(
+                task_ids = create_task_ids(
+                  create_task_id("origin_date",
+                    required = NULL,
+                    optional = c(
+                      "2023-01-02",
+                      "2023-01-09",
+                      "2023-01-16"
+                    )
+                  ),
+                  create_task_id("location",
+                    required = "US",
+                    optional = c("01", "02", "04", "05", "06")
+                  ),
+                  create_task_id("horizon",
+                    required = 1L,
+                    optional = 2:4
+                  )
+                ),
+                output_type = create_output_type(
+                  create_output_type_mean(
+                    is_required = TRUE,
+                    value_type = "double",
+                    value_minimum = 0L
+                  )
+                ),
+                target_metadata = create_target_metadata(
+                  create_target_metadata_item(
+                    target_id = "inc hosp",
+                    target_name = "Weekly incident influenza hospitalizations",
+                    target_units = "rate per 100,000 population",
+                    target_keys = NULL,
+                    target_type = "discrete",
+                    is_step_ahead = TRUE,
+                    time_unit = "week"
+                  )
                 )
-              ),
-              create_task_id("location",
-                required = "US",
-                optional = c("01", "02", "04", "05", "06")
-              ),
-              create_task_id("horizon",
-                required = 1L,
-                optional = 2:4
               )
             ),
-            output_type = create_output_type(
-              create_output_type_mean(
-                is_required = TRUE,
-                value_type = "double",
-                value_minimum = 0L
-              )
-            ),
-            target_metadata = create_target_metadata(
-              create_target_metadata_item(
-                target_id = "inc hosp",
-                target_name = "Weekly incident influenza hospitalizations",
-                target_units = "rate per 100,000 population",
-                target_keys = NULL,
-                target_type = "discrete",
-                is_step_ahead = TRUE,
-                time_unit = "week"
-              )
+            submissions_due = list(
+              relative_to = "origin_date",
+              start = -4L,
+              end = 2L
             )
           )
-        ),
-        submissions_due = list(
-          relative_to = "origin_date",
-          start = -4L,
-          end = 2L
         )
       )
-    )
-  )
 
-  # Compare list representations of the config and the schema autoboxed config
-  expect_snapshot(waldo::compare(config, schema_autobox(config)))
+      # Compare list representations of the config and the schema autoboxed config
+      expect_snapshot(waldo::compare(config, schema_autobox(config)))
 
-  # Compare JSON representations of the config and the schema autoboxed config
-  expect_snapshot(
-    schema_autobox(config) |>
-      jsonlite::toJSON(
-        auto_unbox = TRUE, na = "string",
-        null = "null", pretty = TRUE
+      # Compare JSON representations of the config and the schema autoboxed config
+      expect_snapshot(
+        schema_autobox(config) |>
+          jsonlite::toJSON(
+            auto_unbox = TRUE, na = "string",
+            null = "null", pretty = TRUE
+          )
       )
-  )
-  expect_snapshot(
-    waldo::compare(
-      config$rounds[[1]]$model_tasks[[1]]$task_ids$location$required |>
-        jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
-        ),
-      schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$task_ids$location$required |>
-        jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
+      expect_snapshot(
+        waldo::compare(
+          config$rounds[[1]]$model_tasks[[1]]$task_ids$location$required |>
+            jsonlite::toJSON(
+              auto_unbox = TRUE, na = "string",
+              null = "null", pretty = TRUE
+            ),
+          schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$task_ids$location$required |>
+            jsonlite::toJSON(
+              auto_unbox = TRUE, na = "string",
+              null = "null", pretty = TRUE
+            )
         )
-    )
-  )
-
-  expect_snapshot(
-    waldo::compare(
-      config$rounds[[1]]$model_tasks[[1]]$task_ids$horizon$required |>
-        jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
-        ),
-      schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$task_ids$horizon$required |>
-        jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
-        )
-    )
-  )
-
-  expect_snapshot(
-    waldo::compare(
-      config$rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id$required |>
-        jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
-        ),
-      schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id$required |>
-        jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
-        )
-    )
-  )
-
-  # Add more rounds & modeling tasks
-  more_rounds_config <- config
-  more_rounds_config$rounds <- c(
-    config$rounds,
-    config$rounds
-  )
-  more_rounds_config$rounds[[1]]$model_tasks <- list(
-    config$rounds[[1]]$model_tasks[[1]],
-    config$rounds[[1]]$model_tasks[[1]]
-  )
-
-  expect_snapshot(
-    schema_autobox(more_rounds_config) |>
-      jsonlite::toJSON(
-        auto_unbox = TRUE, na = "string",
-        null = "null", pretty = TRUE
       )
+
+      expect_snapshot(
+        waldo::compare(
+          config$rounds[[1]]$model_tasks[[1]]$task_ids$horizon$required |>
+            jsonlite::toJSON(
+              auto_unbox = TRUE, na = "string",
+              null = "null", pretty = TRUE
+            ),
+          schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$task_ids$horizon$required |>
+            jsonlite::toJSON(
+              auto_unbox = TRUE, na = "string",
+              null = "null", pretty = TRUE
+            )
+        )
+      )
+
+      expect_snapshot(
+        waldo::compare(
+          config$rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id$required |>
+            jsonlite::toJSON(
+              auto_unbox = TRUE, na = "string",
+              null = "null", pretty = TRUE
+            ),
+          schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id$required |>
+            jsonlite::toJSON(
+              auto_unbox = TRUE, na = "string",
+              null = "null", pretty = TRUE
+            )
+        )
+      )
+
+      # Add more rounds & modeling tasks
+      more_rounds_config <- config
+      more_rounds_config$rounds <- c(
+        config$rounds,
+        config$rounds
+      )
+      more_rounds_config$rounds[[1]]$model_tasks <- list(
+        config$rounds[[1]]$model_tasks[[1]],
+        config$rounds[[1]]$model_tasks[[1]]
+      )
+
+      expect_snapshot(
+        schema_autobox(more_rounds_config) |>
+          jsonlite::toJSON(
+            auto_unbox = TRUE, na = "string",
+            null = "null", pretty = TRUE
+          )
+      )
+    }
   )
 })
 

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -186,7 +186,6 @@ test_that("target keys error if arrays passed", {
     "testdata",
     "tasks-target-key-array-v4.json"
   )
-  # TODO: remove branch argument when v4.0.0 is released.
   out_v4 <- suppressMessages(validate_config(
     config_path = config_path,
     schema_version = "v4.0.0"
@@ -258,9 +257,7 @@ test_that("v5.0.0 target keys with 2 properties throws error", {
   config_path <- testthat::test_path("testdata", "v5.0.0-tasks-2-target_keys.json")
   out <- suppressMessages(
     validate_config(
-      config_path = config_path,
-      # TDOD: remove branch argument when v5.0.0 is released.
-      branch = "br-v5.0.0"
+      config_path = config_path
     )
   )
   expect_false(out)
@@ -277,9 +274,7 @@ test_that("v5.0.0 target keys with NULL properties passes", {
   config_path <- testthat::test_path("testdata", "v5.0.0-tasks-null-target_keys.json")
   out <- suppressMessages(
     validate_config(
-      config_path = config_path,
-      # TDOD: remove branch argument when v5.0.0 is released.
-      branch = "br-v5.0.0"
+      config_path = config_path
     )
   )
   expect_true(out)
@@ -287,8 +282,7 @@ test_that("v5.0.0 target keys with NULL properties passes", {
 
 test_that("v5.0.0 round_id pattern validation works", {
   skip_if_offline()
-  # TODO: remove branch argument when v5.0.0 is released.
-  schema <- download_tasks_schema("v5.0.0", branch = "br-v5.0.0")
+  schema <- download_tasks_schema("v5.0.0")
 
   # Test that regex pattern matching for round_id properties in jsonvalidate
   # identifies expected errors (when round_id_from_variable: false).
@@ -298,8 +292,7 @@ test_that("v5.0.0 round_id pattern validation works", {
         config_path = testthat::test_path(
           "testdata",
           "v5.0.0-tasks-fail-round-id-pattern.json"
-        ),
-        branch = "br-v5.0.0"
+        )
       )
     )
   )
@@ -326,8 +319,7 @@ test_that("v5.0.0 round_id pattern validation works", {
         config_path = testthat::test_path(
           "testdata",
           "v5.0.0-tasks-fail-round-id-val-pattern.json"
-        ),
-        branch = "br-v5.0.0"
+        )
       )
     )
   )


### PR DESCRIPTION
This PR resolves #93 and is designed to make updating tests when new schema are released much smoother

More specifically it adds helper function `verify_latest_schema_version()` which checks that the `schema_id` attribute of the output of any of the `create_*()` family of functions matches the latest available schema version. If it does, it overwrites the `schema_id` attribute (and `schema_version` property in a config class object) with `"latest"`. 

This in turn means we do not have to update the version number of expected outputs everytime a new schema is released in tests where we want to be checking the outputs of functions against the latest schema.

I also fixed the versions of some tests which weren't testing functionality affected by changes in schema.

 I also removed any obsolete mentions of specific branches (these will no longer be required with the new `hubUtils` workflow anyways in future as the schema under development will be available in the dev version of `hubUtils`)
