### PR TITLE
Detect duplicate property names in config

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubAdmin (development version)
 
+* `validate_config()` now detects the presence of duplicate property names (#98).
+
 # hubAdmin 1.5.0
 
 * Use options to set `schema_version` and `branch` arguments in `download_tasks_schema()` and the `create_*()` family of functions for creating config files programmatically. This allows for setting the schema version and branch globally for the session (#85).

--- a/R/append_additional_properties.R
+++ b/R/append_additional_properties.R
@@ -78,5 +78,5 @@ add_items <- function(config_path, schema_path) {
   non_items_idx <- which(schema_path != "items")
   out <- schema_path
   out[non_items_idx] <- config_path
-  return(out)
+  out
 }

--- a/R/append_round.R
+++ b/R/append_round.R
@@ -215,5 +215,5 @@ append_round <- function(config, ...) {
 
   config[["rounds"]] <- c(config[["rounds"]], rounds[["rounds"]])
 
-  return(config)
+  config
 }

--- a/R/collect_items.R
+++ b/R/collect_items.R
@@ -32,7 +32,7 @@ collect_items <- function(...,
       items,
       function(x) {
         attributes(x) <- list(names = names(x))
-        return(x)
+        x
       }
     )
   }

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -127,5 +127,5 @@ check_output_type_id_datatype <- function(schema_id, output_type_id_datatype) {
     )
     return(NULL)
   }
-  return(output_type_id_datatype)
+  output_type_id_datatype
 }

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -45,6 +45,13 @@ get_error_path <- function(schema, element = "target_metadata",
                            append_item_n = FALSE) {
   type <- rlang::arg_match(type)
 
+  # Return appropriate path early if element indicates root of config (i.e. is "/")
+  if (element == "/" && type == "schema") {
+    return(paste0("#", element))
+  }
+  if (element == "/") {
+    return(element)
+  }
   # Create a character vector of schema paths
   schema_paths <- schema %>%
     jsonlite::fromJSON(simplifyDataFrame = FALSE) %>%

--- a/R/get_error_path.R
+++ b/R/get_error_path.R
@@ -40,7 +40,7 @@
 #' get_error_path(schema, "derived_task_ids", "schema")
 #' # Target lower level properties by defining more of the path
 #' get_error_path(schema, "rounds/items/properties/derived_task_ids", "schema")
-get_error_path <- function(schema, element = "target_metadata",
+get_error_path <- function(schema, element = "target_metadata", # nolint: cyclocomp_linter
                            type = c("schema", "instance"),
                            append_item_n = FALSE) {
   type <- rlang::arg_match(type)

--- a/R/schema_autobox.R
+++ b/R/schema_autobox.R
@@ -204,7 +204,7 @@ expand_items <- function(x, config) {
   purrr::map(seq_len(item_n), \(.x, item_idx) {
     x <- as.list(x)
     x[[item_idx]] <- as.integer(.x)
-    return(x)
+    x
   }, item_idx = item_idx)
 }
 
@@ -220,5 +220,5 @@ expand_path_items <- function(path, config) {
     ) |>
       purrr::list_flatten()
   }
-  return(path)
+  path
 }

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -1029,6 +1029,7 @@ parse_object_path <- function(object_path) {
     return(meta)
   }
 
+  # Identify integer indices in the path
   indices <- suppressWarnings(purrr::map(path_meta, as.integer))
   int_indices <- purrr::discard(indices, is.na)
   if (length(int_indices) > 0L) {

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -478,6 +478,39 @@ validate_mt_property_unique_vals <- function(model_task_grp,
   }
 }
 
+validate_mt_property_unique_names <- function(model_task_grp,
+                                              model_task_i,
+                                              round_i,
+                                              property = c(
+                                                "task_ids",
+                                                "output_type"
+                                              ),
+                                              schema) {
+  property <- rlang::arg_match(property)
+
+  property_names <- switch(property,
+    task_ids = model_task_grp[["task_ids"]],
+    output_type = model_task_grp[["output_type"]]
+  ) |> names()
+
+    dup_names <- property_names[duplicated(property_names)]
+
+  if(length(dup_names) == 0L) {
+    return(NULL)
+  } else {
+    data.frame(
+      instancePath = glue::glue(
+        get_error_path(schema, paste0("/", property), "instance")),
+      schemaPath = get_error_path(schema, paste0("/", property), "schema"),
+      keyword = glue::glue("{property} uniqueNames"),
+      message = glue::glue("{property} objects must NOT contain
+                           properties with duplicate names"),
+      schema = "",
+      data = glue::glue("duplicate names: {paste(dup_names, collapse = ', ')}")
+    )
+  }
+}
+
 # Check that modeling task round ids match the expected round ID patterns when
 # round_id_from_variable = TRUE
 validate_mt_round_id_pattern <- function(model_task_grp,

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -1032,7 +1032,11 @@ parse_object_path <- function(object_path) {
   indices <- suppressWarnings(purrr::map(path_meta, as.integer))
   int_indices <- purrr::discard(indices, is.na)
   if (length(int_indices) > 0L) {
-    meta[seq_along(int_indices) + 2] <- int_indices
+    # Populate "round_i", "model_task_i", "target_key_i" with integer indices
+    # depending on the depth of the current path (i.e. the length of the vector of
+    # integer indices present in the path). The + 2 is used to skip populating
+    # the first two elements of `meta`.
+    meta[seq_along(int_indices) + 2L] <- int_indices
   }
   meta[["object_name"]] <- path_meta[utils::tail(which(is.na(indices)), 1L)]
   meta

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -478,32 +478,37 @@ validate_mt_property_unique_vals <- function(model_task_grp,
   }
 }
 
-validate_mt_property_unique_names <- function(model_task_grp,
-                                              model_task_i,
-                                              round_i,
-                                              property = c(
-                                                "task_ids",
-                                                "output_type"
-                                              ),
-                                              schema) {
-  property <- rlang::arg_match(property)
+validate_property_unique_names <- function(object_config,
+                                           model_task_i = NULL,
+                                           round_i = NULL,
+                                           object_name = c(
+                                             "task_ids",
+                                             "output_type",
+                                             "config"
+                                           ),
+                                           schema) {
+  object_name <- rlang::arg_match(object_name)
 
-  property_names <- switch(property,
-    task_ids = model_task_grp[["task_ids"]],
-    output_type = model_task_grp[["output_type"]]
+  property_names <- switch(object_name,
+    task_ids = object_config[["task_ids"]],
+    output_type = object_config[["output_type"]],
+    config = object_config
   ) |> names()
 
-    dup_names <- property_names[duplicated(property_names)]
+  dup_names <- property_names[duplicated(property_names)]
 
-  if(length(dup_names) == 0L) {
+  object_path_target <- ifelse(object_name == "config", "", object_name)
+
+  if (length(dup_names) == 0L) {
     return(NULL)
   } else {
     data.frame(
       instancePath = glue::glue(
-        get_error_path(schema, paste0("/", property), "instance")),
-      schemaPath = get_error_path(schema, paste0("/", property), "schema"),
-      keyword = glue::glue("{property} uniqueNames"),
-      message = glue::glue("{property} objects must NOT contain
+        get_error_path(schema, paste0("/", object_path_target), "instance")
+      ),
+      schemaPath = get_error_path(schema, paste0("/", object_path_target), "schema"),
+      keyword = glue::glue("{object_name} uniqueNames"),
+      message = glue::glue("{object_name} objects must NOT contain
                            properties with duplicate names"),
       schema = "",
       data = glue::glue("duplicate names: {paste(dup_names, collapse = ', ')}")

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -502,7 +502,8 @@ validate_property_unique_names <- function(object_config,
                                              "output_type",
                                              "config",
                                              "round",
-                                             "target_metadata"
+                                             "target_metadata",
+                                             "model_task"
                                            ),
                                            schema) {
   object_name <- rlang::arg_match(object_name)
@@ -518,9 +519,10 @@ validate_property_unique_names <- function(object_config,
   object_path_target <- switch(object_name,
     config = "",
     round = "rounds",
+    model_task = "model_tasks",
     object_name
   )
-  append_item_n <- object_name %in% c("round", "target_metadata")
+  append_item_n <- object_name %in% c("round", "target_metadata", "model_task")
 
   if (length(dup_names) == 0L) {
     return(NULL)

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -33,7 +33,7 @@ val_task_id_names <- function(model_task_grp, model_task_i, round_i, schema) {
     return(error_row)
   }
 
-  return(NULL)
+  NULL
 }
 
 val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
@@ -148,7 +148,7 @@ val_target_key_names_const <- function(grp_target_keys, model_task_grp,
     )
     return(error_row)
   }
-  return(NULL)
+  NULL
 }
 
 val_target_key_names <- function(target_keys, model_task_grp,
@@ -170,9 +170,9 @@ val_target_key_names <- function(target_keys, model_task_grp,
             target_key names: {glue::glue_collapse(names(target_keys), sep = ', ')}")
     )
 
-    return(error_row)
+    error_row
   } else {
-    return(NULL)
+    NULL
   }
 }
 
@@ -215,9 +215,9 @@ val_target_key_values <- function(target_keys, model_task_grp,
       )
     )
 
-    return(error_row)
+    error_row
   } else {
-    return(NULL)
+    NULL
   }
 }
 
@@ -287,8 +287,7 @@ val_target_key_task_id_values <- function(grp_target_keys,
     )
     return(error_row)
   }
-
-  return(NULL)
+  NULL
 }
 
 
@@ -372,7 +371,7 @@ validate_mt_sample_range <- function(model_task_grp,
     )
     return(error_row)
   }
-  return(NULL)
+  NULL
 }
 
 # Validate that compound_taskid_set values are valid task ids for a
@@ -429,7 +428,7 @@ validate_mt_sample_compound_taskids <- function(model_task_grp,
     )
     return(error_row)
   }
-  return(NULL)
+  NULL
 }
 
 validate_mt_property_unique_vals <- function(model_task_grp,
@@ -595,7 +594,7 @@ validate_mt_round_id_pattern <- function(model_task_grp,
       schema = "^([0-9]{4}-[0-9]{2}-[0-9]{2})$|^[A-Za-z0-9_]+$",
       data = glue::glue("invalid values: {invalid_vals_msg}")
     )
-    return(error_row)
+    error_row
   }
 }
 ## ROUND LEVEL VALIDATIONS ----
@@ -816,7 +815,7 @@ validate_task_ids_not_all_null <- function(config_tasks, schema) {
     return(error_row)
   }
 
-  return(data.frame())
+  data.frame()
 }
 
 # Check that config derived_task_ids match valid round task ID names
@@ -999,7 +998,7 @@ assert_config_exists <- function(path) {
   if (!isTRUE(validation)) {
     validation <- make_config_error(path, validation)
   }
-  return(validation)
+  validation
 }
 
 make_config_error <- function(path, msg) {
@@ -1011,5 +1010,5 @@ make_config_error <- function(path, msg) {
   class(validation) <- c("conval", "error")
   # so it doesn't print the actual value, just the message
   utils::capture.output(print(validation))
-  return(validation)
+  validation
 }

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -1031,6 +1031,7 @@ parse_object_path <- function(object_path) {
 
   # Identify integer indices in the path
   indices <- suppressWarnings(purrr::map(path_meta, as.integer))
+  # Remove non-integer indices
   int_indices <- purrr::discard(indices, is.na)
   if (length(int_indices) > 0L) {
     # Populate "round_i", "model_task_i", "target_key_i" with integer indices

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -815,7 +815,9 @@ validate_unique_names_recursive <- function(object, object_path = "", schema) {
   # Initialise objects to be assigned via env_bind to silence R CMD check note
   object_name <- NULL
   object_target_path <- NULL
-  # Assign elements required for error messages and path tracking to variables
+  # Assign elements required for error messages and path tracking to variables.
+  # This also creates variables `round_i`, `model_task_i` and `target_metadata_i`
+  # used to create instance error paths when glueing the output of get_error_path().
   rlang::env_bind(environment(), !!!parse_object_path(object_path))
 
   property_names <- names(object)

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -107,11 +107,26 @@ val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
     round_i = round_i,
     schema = schema
   )
+
+  # Check that metadata objects do not contain duplicate properties
+  error_check_5 <- purrr::imap(
+    model_task_grp[["target_metadata"]],
+    ~ validate_property_unique_names(
+      object_config = .x,
+      target_key_i = .y,
+      model_task_i = model_task_i,
+      round_i = round_i,
+      object_name = "target_metadata",
+      schema = schema
+    )
+  ) %>%
+    purrr::list_rbind()
   # Combine all error checks
   rbind(
     errors_check_2,
     errors_check_3,
-    errors_check_4
+    errors_check_4,
+    error_check_5
   )
 }
 
@@ -487,6 +502,7 @@ validate_property_unique_names <- function(object_config,
                                              "output_type",
                                              "config",
                                              "round",
+                                             "target_metadata"
                                            ),
                                            schema) {
   object_name <- rlang::arg_match(object_name)

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -150,7 +150,6 @@ perform_dynamic_config_validations <- function(validation) {
   )
   schema <- hubUtils::get_schema(attr(validation, "schema_url"))
 
-
   errors_tbl <- c(
     # Map over Round level validations
     purrr::imap(
@@ -164,7 +163,11 @@ perform_dynamic_config_validations <- function(validation) {
     list(
       validate_round_ids_unique(config_json, schema),
       validate_task_ids_not_all_null(config_json, schema),
-      validate_config_derived_task_ids(config_json, schema)
+      validate_config_derived_task_ids(config_json, schema),
+      validate_property_unique_names(
+        config_json, object_name = "config",
+        schema = schema
+      )
     )
   ) %>%
     purrr::list_rbind()
@@ -221,17 +224,17 @@ val_round <- function(round, round_i, schema) {
     ),
     purrr::imap(
       model_task_grps,
-      ~ validate_mt_property_unique_names(
-        model_task_grp = .x, model_task_i = .y,
-        round_i = round_i, property = "task_ids",
+      ~ validate_property_unique_names(
+        object_config = .x, model_task_i = .y,
+        round_i = round_i, object_name = "task_ids",
         schema = schema
       )
     ),
     purrr::imap(
       model_task_grps,
-      ~ validate_mt_property_unique_names(
-        model_task_grp = .x, model_task_i = .y,
-        round_i = round_i, property = "output_type",
+      ~ validate_property_unique_names(
+        object_config = .x, model_task_i = .y,
+        round_i = round_i, object_name = "output_type",
         schema = schema
       )
     ),

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -164,10 +164,7 @@ perform_dynamic_config_validations <- function(validation) {
       validate_round_ids_unique(config_json, schema),
       validate_task_ids_not_all_null(config_json, schema),
       validate_config_derived_task_ids(config_json, schema),
-      validate_property_unique_names(
-        config_json, object_name = "config",
-        schema = schema
-      )
+      validate_unique_names_recursive(config_json, schema = schema)
     )
   ) %>%
     purrr::list_rbind()
@@ -224,30 +221,6 @@ val_round <- function(round, round_i, schema) {
     ),
     purrr::imap(
       model_task_grps,
-      ~ validate_property_unique_names(
-        object_config = .x, model_task_i = .y,
-        round_i = round_i, object_name = "model_task",
-        schema = schema
-      )
-    ),
-    purrr::imap(
-      model_task_grps,
-      ~ validate_property_unique_names(
-        object_config = .x, model_task_i = .y,
-        round_i = round_i, object_name = "task_ids",
-        schema = schema
-      )
-    ),
-    purrr::imap(
-      model_task_grps,
-      ~ validate_property_unique_names(
-        object_config = .x, model_task_i = .y,
-        round_i = round_i, object_name = "output_type",
-        schema = schema
-      )
-    ),
-    purrr::imap(
-      model_task_grps,
       ~ validate_mt_sample_range(
         model_task_grp = .x, model_task_i = .y,
         round_i = round_i,
@@ -282,11 +255,6 @@ val_round <- function(round, round_i, schema) {
       ),
       validate_round_derived_task_ids(
         round = round,
-        round_i = round_i,
-        schema = schema
-      ),
-      validate_property_unique_names(
-        round, object_name = "round",
         round_i = round_i,
         schema = schema
       )

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -226,6 +226,14 @@ val_round <- function(round, round_i, schema) {
       model_task_grps,
       ~ validate_property_unique_names(
         object_config = .x, model_task_i = .y,
+        round_i = round_i, object_name = "model_task",
+        schema = schema
+      )
+    ),
+    purrr::imap(
+      model_task_grps,
+      ~ validate_property_unique_names(
+        object_config = .x, model_task_i = .y,
         round_i = round_i, object_name = "task_ids",
         schema = schema
       )

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -221,6 +221,22 @@ val_round <- function(round, round_i, schema) {
     ),
     purrr::imap(
       model_task_grps,
+      ~ validate_mt_property_unique_names(
+        model_task_grp = .x, model_task_i = .y,
+        round_i = round_i, property = "task_ids",
+        schema = schema
+      )
+    ),
+    purrr::imap(
+      model_task_grps,
+      ~ validate_mt_property_unique_names(
+        model_task_grp = .x, model_task_i = .y,
+        round_i = round_i, property = "output_type",
+        schema = schema
+      )
+    ),
+    purrr::imap(
+      model_task_grps,
       ~ validate_mt_sample_range(
         model_task_grp = .x, model_task_i = .y,
         round_i = round_i,

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -179,7 +179,7 @@ perform_dynamic_config_validations <- function(validation) {
     )
   }
 
-  return(validation)
+  validation
 }
 
 ## Dynamic schema validation utilities ----

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -276,6 +276,11 @@ val_round <- function(round, round_i, schema) {
         round = round,
         round_i = round_i,
         schema = schema
+      ),
+      validate_property_unique_names(
+        round, object_name = "round",
+        round_i = round_i,
+        schema = schema
       )
     )
   ) %>%

--- a/tests/testthat/helper-verify_latest_schema_version.R
+++ b/tests/testthat/helper-verify_latest_schema_version.R
@@ -12,6 +12,5 @@ verify_latest_schema_version <- function(x) {
   if (!is.null(x$schema_version)) {
     x$schema_version <- "latest"
   }
-
-  return(x)
+  x
 }

--- a/tests/testthat/helper-write_config.R
+++ b/tests/testthat/helper-write_config.R
@@ -72,7 +72,7 @@ create_test_config <- function(rounds) {
 setup_test_hub <- function() {
   dir <- withr::local_tempdir()
   temp_hub <- fs::dir_create(fs::path(dir, "hub"))
-  return(temp_hub)
+  temp_hub
 }
 
 setup_test_hub_with_config_dir <- function(temp_hub) {

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -360,51 +360,38 @@ test_that("Duplicate property names are flagged during validation", {
   expect_equal(
     unique(errors_vals$instancePath),
     c(
-      "/rounds/0/model_tasks/0/target_metadata/0",
-      "/rounds/0/model_tasks/0",
-      "/rounds/0/model_tasks/0/task_ids",
-      "/rounds/0/model_tasks/0/output_type",
-      "/rounds/0",
-      "/"
+      "/", "/rounds/0", "/rounds/0/model_tasks/0", "/rounds/0/model_tasks/0/task_ids",
+      "/rounds/0/model_tasks/0/output_type", "/rounds/0/model_tasks/0/target_metadata/0"
     )
   )
   expect_equal(
     unique(errors_vals$schemaPath),
-    c(
-      "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata",
-      "#/properties/rounds/items/properties/model_tasks",
+    c("#/", "#/properties/rounds", "#/properties/rounds/items/properties/model_tasks",
       "#/properties/rounds/items/properties/model_tasks/items/properties/task_ids",
       "#/properties/rounds/items/properties/model_tasks/items/properties/output_type",
-      "#/properties/rounds",
-      "#/"
+      "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata"
     )
   )
   expect_equal(
     unique(errors_vals$keyword),
-    c(
-      "target_metadata uniqueNames", "model_task uniqueNames", "task_ids uniqueNames",
-      "output_type uniqueNames", "round uniqueNames",
-      "config uniqueNames"
+    c("config uniqueNames", "rounds uniqueNames", "model_tasks uniqueNames",
+      "task_ids uniqueNames", "output_type uniqueNames", "target_metadata uniqueNames"
     )
   )
   expect_equal(
     unique(errors_vals$message),
-    c(
-      "target_metadata objects must NOT contain\nproperties with duplicate names",
-      "model_task objects must NOT contain\nproperties with duplicate names",
+    c("config objects must NOT contain\nproperties with duplicate names",
+      "rounds objects must NOT contain\nproperties with duplicate names",
+      "model_tasks objects must NOT contain\nproperties with duplicate names",
       "task_ids objects must NOT contain\nproperties with duplicate names",
       "output_type objects must NOT contain\nproperties with duplicate names",
-      "round objects must NOT contain\nproperties with duplicate names",
-      "config objects must NOT contain\nproperties with duplicate names"
+      "target_metadata objects must NOT contain\nproperties with duplicate names"
     )
   )
   expect_equal(
     unique(errors_vals$data),
-    c(
-      "duplicate names: target_id", "duplicate names: target_metadata",
-      "duplicate names: horizon", "duplicate names: quantile",
-      "duplicate names: round_id, derived_task_ids",
-      "duplicate names: schema_version"
-    )
+    c("duplicate names: schema_version", "duplicate names: round_id, derived_task_ids",
+      "duplicate names: target_metadata", "duplicate names: horizon",
+      "duplicate names: quantile", "duplicate names: target_id")
   )
 })

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -356,12 +356,13 @@ test_that("Duplicate property names are flagged during validation", {
   ))
   expect_false(val)
   errors_vals <- attr(val, "errors")
-  expect_equal(nrow(errors_vals), 3L)
+  expect_equal(nrow(errors_vals), 4L)
   expect_equal(
     unique(errors_vals$instancePath),
     c(
       "/rounds/0/model_tasks/0/task_ids",
       "/rounds/0/model_tasks/0/output_type",
+      "/rounds/0",
       "/"
     )
   )
@@ -370,18 +371,21 @@ test_that("Duplicate property names are flagged during validation", {
     c(
       "#/properties/rounds/items/properties/model_tasks/items/properties/task_ids",
       "#/properties/rounds/items/properties/model_tasks/items/properties/output_type",
+      "#/properties/rounds",
       "#/"
     )
   )
   expect_equal(
     unique(errors_vals$keyword),
-    c("task_ids uniqueNames", "output_type uniqueNames", "config uniqueNames")
+    c("task_ids uniqueNames", "output_type uniqueNames", "round uniqueNames",
+      "config uniqueNames")
   )
   expect_equal(
     unique(errors_vals$message),
     c(
       "task_ids objects must NOT contain\nproperties with duplicate names",
       "output_type objects must NOT contain\nproperties with duplicate names",
+      "round objects must NOT contain\nproperties with duplicate names",
       "config objects must NOT contain\nproperties with duplicate names"
     )
   )
@@ -389,7 +393,7 @@ test_that("Duplicate property names are flagged during validation", {
     unique(errors_vals$data),
     c(
       "duplicate names: horizon", "duplicate names: quantile",
-      "duplicate names: schema_version"
+      "duplicate names: round_id", "duplicate names: schema_version"
     )
   )
 })

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -356,11 +356,12 @@ test_that("Duplicate property names are flagged during validation", {
   ))
   expect_false(val)
   errors_vals <- attr(val, "errors")
-  expect_equal(nrow(errors_vals), 5L)
+  expect_equal(nrow(errors_vals), 6L)
   expect_equal(
     unique(errors_vals$instancePath),
     c(
       "/rounds/0/model_tasks/0/target_metadata/0",
+      "/rounds/0/model_tasks/0",
       "/rounds/0/model_tasks/0/task_ids",
       "/rounds/0/model_tasks/0/output_type",
       "/rounds/0",
@@ -371,6 +372,7 @@ test_that("Duplicate property names are flagged during validation", {
     unique(errors_vals$schemaPath),
     c(
       "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata",
+      "#/properties/rounds/items/properties/model_tasks",
       "#/properties/rounds/items/properties/model_tasks/items/properties/task_ids",
       "#/properties/rounds/items/properties/model_tasks/items/properties/output_type",
       "#/properties/rounds",
@@ -380,7 +382,7 @@ test_that("Duplicate property names are flagged during validation", {
   expect_equal(
     unique(errors_vals$keyword),
     c(
-      "target_metadata uniqueNames", "task_ids uniqueNames",
+      "target_metadata uniqueNames", "model_task uniqueNames", "task_ids uniqueNames",
       "output_type uniqueNames", "round uniqueNames",
       "config uniqueNames"
     )
@@ -389,6 +391,7 @@ test_that("Duplicate property names are flagged during validation", {
     unique(errors_vals$message),
     c(
       "target_metadata objects must NOT contain\nproperties with duplicate names",
+      "model_task objects must NOT contain\nproperties with duplicate names",
       "task_ids objects must NOT contain\nproperties with duplicate names",
       "output_type objects must NOT contain\nproperties with duplicate names",
       "round objects must NOT contain\nproperties with duplicate names",
@@ -398,9 +401,9 @@ test_that("Duplicate property names are flagged during validation", {
   expect_equal(
     unique(errors_vals$data),
     c(
-      "duplicate names: target_id", "duplicate names: horizon",
-      "duplicate names: quantile", "duplicate names: round_id",
-      "duplicate names: schema_version"
+      "duplicate names: target_id", "duplicate names: target_metadata",
+      "duplicate names: horizon", "duplicate names: quantile",
+      "duplicate names: round_id", "duplicate names: schema_version"
     )
   )
 })

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -403,7 +403,8 @@ test_that("Duplicate property names are flagged during validation", {
     c(
       "duplicate names: target_id", "duplicate names: target_metadata",
       "duplicate names: horizon", "duplicate names: quantile",
-      "duplicate names: round_id", "duplicate names: schema_version"
+      "duplicate names: round_id, derived_task_ids",
+      "duplicate names: schema_version"
     )
   )
 })

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -356,10 +356,11 @@ test_that("Duplicate property names are flagged during validation", {
   ))
   expect_false(val)
   errors_vals <- attr(val, "errors")
-  expect_equal(nrow(errors_vals), 4L)
+  expect_equal(nrow(errors_vals), 5L)
   expect_equal(
     unique(errors_vals$instancePath),
     c(
+      "/rounds/0/model_tasks/0/target_metadata/0",
       "/rounds/0/model_tasks/0/task_ids",
       "/rounds/0/model_tasks/0/output_type",
       "/rounds/0",
@@ -369,6 +370,7 @@ test_that("Duplicate property names are flagged during validation", {
   expect_equal(
     unique(errors_vals$schemaPath),
     c(
+      "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata",
       "#/properties/rounds/items/properties/model_tasks/items/properties/task_ids",
       "#/properties/rounds/items/properties/model_tasks/items/properties/output_type",
       "#/properties/rounds",
@@ -377,12 +379,16 @@ test_that("Duplicate property names are flagged during validation", {
   )
   expect_equal(
     unique(errors_vals$keyword),
-    c("task_ids uniqueNames", "output_type uniqueNames", "round uniqueNames",
-      "config uniqueNames")
+    c(
+      "target_metadata uniqueNames", "task_ids uniqueNames",
+      "output_type uniqueNames", "round uniqueNames",
+      "config uniqueNames"
+    )
   )
   expect_equal(
     unique(errors_vals$message),
     c(
+      "target_metadata objects must NOT contain\nproperties with duplicate names",
       "task_ids objects must NOT contain\nproperties with duplicate names",
       "output_type objects must NOT contain\nproperties with duplicate names",
       "round objects must NOT contain\nproperties with duplicate names",
@@ -392,8 +398,9 @@ test_that("Duplicate property names are flagged during validation", {
   expect_equal(
     unique(errors_vals$data),
     c(
-      "duplicate names: horizon", "duplicate names: quantile",
-      "duplicate names: round_id", "duplicate names: schema_version"
+      "duplicate names: target_id", "duplicate names: horizon",
+      "duplicate names: quantile", "duplicate names: round_id",
+      "duplicate names: schema_version"
     )
   )
 })

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -348,3 +348,42 @@ test_that("v5.0.0 round_id pattern validation works", {
     ), class = c("glue", "character"))
   )
 })
+
+test_that("Duplicate property names are flagged during validation", {
+  val <- validate_config(config_path = test_path(
+    "testdata",
+    "v5.0.0-dup-prop-names.json"
+  ))
+  expect_false(val)
+  errors_vals <- attr(val, "errors")
+  expect_equal(nrow(errors_vals), 2L)
+  expect_equal(
+    unique(errors_vals$instancePath),
+    c(
+      "/rounds/0/model_tasks/0/task_ids",
+      "/rounds/0/model_tasks/0/output_type"
+    )
+  )
+  expect_equal(
+    unique(errors_vals$schemaPath),
+    c(
+      "#/properties/rounds/items/properties/model_tasks/items/properties/task_ids",
+      "#/properties/rounds/items/properties/model_tasks/items/properties/output_type"
+    )
+  )
+  expect_equal(
+    unique(errors_vals$keyword),
+    c("task_ids uniqueNames", "output_type uniqueNames")
+  )
+  expect_equal(
+    unique(errors_vals$message),
+    c(
+      "task_ids objects must NOT contain\nproperties with duplicate names",
+      "output_type objects must NOT contain\nproperties with duplicate names"
+    )
+  )
+  expect_equal(
+    unique(errors_vals$data),
+    c("duplicate names: horizon", "duplicate names: quantile")
+  )
+})

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -356,34 +356,40 @@ test_that("Duplicate property names are flagged during validation", {
   ))
   expect_false(val)
   errors_vals <- attr(val, "errors")
-  expect_equal(nrow(errors_vals), 2L)
+  expect_equal(nrow(errors_vals), 3L)
   expect_equal(
     unique(errors_vals$instancePath),
     c(
       "/rounds/0/model_tasks/0/task_ids",
-      "/rounds/0/model_tasks/0/output_type"
+      "/rounds/0/model_tasks/0/output_type",
+      "/"
     )
   )
   expect_equal(
     unique(errors_vals$schemaPath),
     c(
       "#/properties/rounds/items/properties/model_tasks/items/properties/task_ids",
-      "#/properties/rounds/items/properties/model_tasks/items/properties/output_type"
+      "#/properties/rounds/items/properties/model_tasks/items/properties/output_type",
+      "#/"
     )
   )
   expect_equal(
     unique(errors_vals$keyword),
-    c("task_ids uniqueNames", "output_type uniqueNames")
+    c("task_ids uniqueNames", "output_type uniqueNames", "config uniqueNames")
   )
   expect_equal(
     unique(errors_vals$message),
     c(
       "task_ids objects must NOT contain\nproperties with duplicate names",
-      "output_type objects must NOT contain\nproperties with duplicate names"
+      "output_type objects must NOT contain\nproperties with duplicate names",
+      "config objects must NOT contain\nproperties with duplicate names"
     )
   )
   expect_equal(
     unique(errors_vals$data),
-    c("duplicate names: horizon", "duplicate names: quantile")
+    c(
+      "duplicate names: horizon", "duplicate names: quantile",
+      "duplicate names: schema_version"
+    )
   )
 })

--- a/tests/testthat/testdata/v5.0.0-dup-prop-names.json
+++ b/tests/testthat/testdata/v5.0.0-dup-prop-names.json
@@ -137,6 +137,7 @@
                     "target_metadata": [
                         {
                             "target_id": "wk ahead inc flu hosp",
+                            "target_id": "wk ahead inc flu hosp",
                             "target_name": "weekly influenza hospitalization incidence",
                             "target_units": "rate per 100,000 population",
                             "target_keys": {

--- a/tests/testthat/testdata/v5.0.0-dup-prop-names.json
+++ b/tests/testthat/testdata/v5.0.0-dup-prop-names.json
@@ -1,0 +1,161 @@
+{
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/tasks-schema.json",
+    "rounds": [
+        {
+            "round_id_from_variable": true,
+            "round_id": "forecast_date",
+            "model_tasks": [
+                {
+                    "task_ids": {
+                        "forecast_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-12-12",
+                                "2022-12-19",
+                                "2022-12-26",
+                                "2023-01-02",
+                                "2023-01-09",
+                                "2023-01-16",
+                                "2023-01-23",
+                                "2023-01-30",
+                                "2023-02-06",
+                                "2023-02-13",
+                                "2023-02-20",
+                                "2023-02-27",
+                                "2023-03-06",
+                                "2023-03-13",
+                                "2023-03-20",
+                                "2023-03-27",
+                                "2023-04-03",
+                                "2023-04-10",
+                                "2023-04-17",
+                                "2023-04-24",
+                                "2023-05-01"
+                            ]
+                        },
+                        "target": {
+                            "required": null,
+                            "optional": [
+                                "wk ahead inc flu hosp"
+                            ]
+                        },
+                        "horizon": {
+                            "required": [
+                                2
+                            ],
+                            "optional": [
+                                1
+                            ]
+                        },
+                        "horizon": {
+                            "required": [
+                                2
+                            ],
+                            "optional": [
+                                1
+                            ]
+                        },
+                        "location": {
+                            "required": [
+                                "US"
+                            ],
+                            "optional": [
+                                "01",
+                                "02"
+                            ]
+                        },
+                        "target_date": {
+                            "required": null,
+                            "optional": [
+                                "2022-12-19",
+                                "2022-12-26",
+                                "2023-01-02",
+                                "2023-01-09",
+                                "2023-01-16",
+                                "2023-01-23",
+                                "2023-01-30",
+                                "2023-02-06",
+                                "2023-02-13",
+                                "2023-02-20",
+                                "2023-02-27",
+                                "2023-03-06",
+                                "2023-03-13",
+                                "2023-03-20",
+                                "2023-03-27",
+                                "2023-04-03",
+                                "2023-04-10",
+                                "2023-04-17",
+                                "2023-04-24",
+                                "2023-05-01",
+                                "2023-05-08",
+                                "2023-05-15"
+                            ]
+                        }
+                    },
+                    "output_type": {
+                        "quantile": {
+                            "output_type_id": {
+                                "required": [
+                                              0.01,0.025,0.05,0.1,0.15,0.2,0.25,
+                                              0.3,0.35,0.4,0.45,0.5,0.55, 0.6,
+                                              0.65,0.7,0.75,0.8,0.85,0.9,0.95,
+                                              0.975,0.99
+                                              ]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            },
+                            "is_required": true
+                        },
+                        "quantile": {
+                            "output_type_id": {
+                                "required": [
+                                    0,
+                                    1
+                                ]
+                            },
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            },
+                            "is_required": false
+                        },
+                        "mean": {
+                            "output_type_id": {
+                                "required": null
+                            },
+                            "is_required": true,
+                            "value": {
+                                "type": "double",
+                                "minimum": 0
+                            }
+                        }
+                    },
+                    "target_metadata": [
+                        {
+                            "target_id": "wk ahead inc flu hosp",
+                            "target_name": "weekly influenza hospitalization incidence",
+                            "target_units": "rate per 100,000 population",
+                            "target_keys": {
+                                "target": "wk ahead inc flu hosp"
+                            },
+                            "target_type": "discrete",
+                            "description": "This target represents the counts of new hospitalizations per horizon week.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+                }
+            ],
+            "submissions_due": {
+                "relative_to": "forecast_date",
+                "start": -6,
+                "end": 2
+            },
+            "derived_task_ids": [
+                "target_date"
+            ]
+        }
+    ]
+}

--- a/tests/testthat/testdata/v5.0.0-dup-prop-names.json
+++ b/tests/testthat/testdata/v5.0.0-dup-prop-names.json
@@ -1,5 +1,6 @@
 {
     "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v5.0.0/tasks-schema.json",
+    "schema_version": "https://raw.githubusercontent.com/hubverse-org/schemas/main/v4.0.0/tasks-schema.json",
     "rounds": [
         {
             "round_id_from_variable": true,

--- a/tests/testthat/testdata/v5.0.0-dup-prop-names.json
+++ b/tests/testthat/testdata/v5.0.0-dup-prop-names.json
@@ -5,6 +5,7 @@
         {
             "round_id_from_variable": true,
             "round_id": "forecast_date",
+            "round_id": "horizon",
             "model_tasks": [
                 {
                     "task_ids": {

--- a/tests/testthat/testdata/v5.0.0-dup-prop-names.json
+++ b/tests/testthat/testdata/v5.0.0-dup-prop-names.json
@@ -172,6 +172,9 @@
             },
             "derived_task_ids": [
                 "target_date"
+            ],
+            "derived_task_ids": [
+                "target_date"
             ]
         }
     ]

--- a/tests/testthat/testdata/v5.0.0-dup-prop-names.json
+++ b/tests/testthat/testdata/v5.0.0-dup-prop-names.json
@@ -148,6 +148,20 @@
                             "is_step_ahead": true,
                             "time_unit": "week"
                         }
+                    ],
+                    "target_metadata": [
+                        {
+                            "target_id": "wk ahead inc flu hosp",
+                            "target_name": "weekly influenza hospitalization incidence",
+                            "target_units": "rate per 100,000 population",
+                            "target_keys": {
+                                "target": "wk ahead inc flu hosp"
+                            },
+                            "target_type": "discrete",
+                            "description": "This target represents the counts of new hospitalizations per horizon week.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
                     ]
                 }
             ],


### PR DESCRIPTION
As surfaced in #98 , JSON validation does not successfully surface objects with duplicate property names as those are removed during json parsing and are therefore never flagged by JSON validatοrs.

This PR adds dynamic validation (in R) that checks for and flags duplicate property names at the following levels:
- config
- round
- model_task
- task_ids
- output_types
- target_metadata

Fortunately, such duplicates were already being checked for or not allowed when creating config objects programmatically so checks only required adding to `validate_config()`


The PR also contains removal of explicit `return()` calls at the end of functions (unless returning early) to conform to the latest lintr rules.