### PR TITLE
Check that `target_id`s match `target_key` values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # hubAdmin (development version)
 
 * `validate_config()` now detects the presence of duplicate property names (#98).
+* `validate_config()` now checks that the `target_id` property in each `target_metadata` item matches the value specified in `target_keys` (#102). Note this check is only performed if `target_keys` is not `NULL` and is does not contain more than one element itself.
 
 # hubAdmin 1.5.0
 

--- a/R/create_target_metadata_item.R
+++ b/R/create_target_metadata_item.R
@@ -124,6 +124,18 @@ create_target_metadata_item <- function(target_id, target_name, target_units,
     call = call
   )
 
+  if (!check_target_id(target_id, target_keys)) {
+    cli::cli_abort(
+      c(
+        "!" = "{.arg target_id} value {.val {target_id}} does not match
+        corresponding {.arg target_keys} value
+        {.val {names(target_keys)}.{unlist(target_keys,
+        use.names = FALSE)}}."
+      ),
+      call = call
+    )
+  }
+
   structure(mget(property_names),
     class = c("target_metadata_item", "list"),
     names = property_names,

--- a/R/create_target_metadata_item.R
+++ b/R/create_target_metadata_item.R
@@ -205,3 +205,19 @@ get_schema_target_metadata <- function(schema) {
     "items", "properties"
   )
 }
+
+check_target_id <- function(target_id, target_keys) {
+  target_key_values <- unlist(target_keys)
+  # Check not possible if target_key is NULL as target_id value
+  # represents the target value.
+  if (is.null(target_key_values)) {
+    return(TRUE)
+  }
+  # skip if target_key length is greater than 1L (i.e. in schema
+  # < v5.0.0). Too messy to perform for older schema but will caught
+  # as error for schema => v5.0.0 by other checks
+  if (length(target_id) != length(target_key_values)) {
+    return(TRUE)
+  }
+  target_id == target_key_values
+}

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -160,22 +160,9 @@ val_target_ids_match_target_key_values <- function(grp_target_keys,
   )
   # Check for mismatches between target_id and target_key values. Returns
   # TRUE if there is a mismatch.
-  mismatch <- purrr::map2_lgl(
+  mismatch <- !purrr::map2_lgl(
     target_ids, target_key_values,
-    ~ {
-      # Check not possible if target_key is NULL as target_id value
-      # represents the target value.
-      if (is.null(.x)) {
-        return(FALSE)
-      }
-      # skip if target_key length is greater than 1L (i.e. in schema
-      # < v5.0.0). Too messy to perform for older schema but will caught
-      # as error for schema => v5.0.0 by other checks
-      if (length(.x) != length(.y)) {
-        return(FALSE)
-      }
-      .x != .y
-    }
+    ~ check_target_id(target_id = .x, target_keys = .y)
   )
 
   if (any(mismatch)) {

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -108,14 +108,22 @@ val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
     schema = schema
   )
 
+  # Check that target_ids match corresponding target key values
+  errors_check_5 <- val_target_ids_match_target_key_values(
+    grp_target_keys,
+    model_task_i = model_task_i,
+    round_i = round_i,
+    schema = schema
+  )
   # Combine all error checks
   rbind(
     errors_check_2,
     errors_check_3,
-    errors_check_4
+    errors_check_4,
+    errors_check_5
   )
 }
-
+## GROUP TARGET KEY LEVEL VALIDATIONS ----
 val_target_key_names_const <- function(grp_target_keys, model_task_grp,
                                        model_task_i, round_i, schema) {
   target_key_names <- purrr::map(grp_target_keys, ~ names(.x)) %>%
@@ -136,7 +144,72 @@ val_target_key_names_const <- function(grp_target_keys, model_task_grp,
   }
   NULL
 }
+# Validate that target_ids match corresponding target key values
+val_target_ids_match_target_key_values <- function(grp_target_keys,
+                                                   model_task_i,
+                                                   round_i,
+                                                   schema) {
+  target_key_values <- purrr::map(
+    grp_target_keys,
+    ~ .x$target_keys |> unlist()
+  )
 
+  target_ids <- purrr::map(
+    grp_target_keys,
+    ~ .x$target_id
+  )
+  # Check for mismatches between target_id and target_key values. Returns
+  # TRUE if there is a mismatch.
+  mismatch <- purrr::map2_lgl(
+    target_ids, target_key_values,
+    ~ {
+      # Check not possible if target_key is NULL as target_id value
+      # represents the target value.
+      if (is.null(.x)) {
+        return(FALSE)
+      }
+      # skip if target_key length is greater than 1L (i.e. in schema
+      # < v5.0.0). Too messy to perform for older schema but will caught
+      # as error for schema => v5.0.0 by other checks
+      if (length(.x) != length(.y)) {
+        return(FALSE)
+      }
+      .x != .y
+    }
+  )
+
+  if (any(mismatch)) {
+    invalid_target_key_values <- target_key_values[mismatch] |>
+      unlist()
+    invalid_target_ids <- target_ids[mismatch] |>
+      unlist()
+    invalid_target_key_idxs <- seq_along(grp_target_keys)[mismatch]
+    error_row <- data.frame(
+      instancePath = glue::glue_data(
+        list(
+          round_i = round_i,
+          model_task_i = model_task_i,
+          target_key_i = invalid_target_key_idxs
+        ),
+        get_error_path(schema, "target_id", "instance",
+          append_item_n = TRUE
+        )
+      ),
+      schemaPath = get_error_path(schema, "target_id", "schema"),
+      keyword = "target_id value",
+      message = "target_id value does not match corresponding target key value",
+      schema = "",
+      data = glue::glue(
+        "target_id value: '{invalid_target_ids}';
+            target_key.{names(invalid_target_key_values)} value: '{invalid_target_key_values}'"
+      )
+    )
+    error_row
+  } else {
+    NULL
+  }
+}
+## TARGET KEY LEVEL VALIDATIONS ----
 val_target_key_names <- function(target_keys, model_task_grp,
                                  target_key_i, model_task_i,
                                  round_i, schema) {

--- a/tests/testthat/_snaps/create_target_metadata.md
+++ b/tests/testthat/_snaps/create_target_metadata.md
@@ -92,13 +92,13 @@
         target_name = "Weekly incident influenza hospitalizations", target_units = "rate per 100,000 population",
         target_keys = list(target = "inc hosp"), target_type = "discrete",
         is_step_ahead = TRUE, time_unit = "week"), create_target_metadata_item(
-        target_id = "inc death", target_name = "Weekly incident influenza deaths",
+        target_id = "inc hosp", target_name = "Weekly incident influenza deaths",
         target_units = "rate per 100,000 population", target_keys = list(target = "inc hosp"),
         target_type = "discrete", is_step_ahead = TRUE, time_unit = "week"))
     Condition
       Error in `create_target_metadata()`:
-      ! `target_keys`s must be unique across all `target_metadata_item`s.
-      x `target_metadata_item` 2 with `target_keys` value list(target = "inc hosp") is duplicate.
+      ! `target_id`s must be unique across all `target_metadata_item`s.
+      x `target_metadata_item` 2 with `target_id` value inc hosp is duplicate.
 
 ---
 
@@ -117,7 +117,7 @@
     Code
       create_target_metadata(item_1, create_target_metadata_item(target_id = "inc death",
         target_name = "Weekly incident influenza deaths", target_units = "rate per 100,000 population",
-        target_keys = list(target = "inc hosp"), target_type = "discrete",
+        target_keys = list(target = "inc death"), target_type = "discrete",
         is_step_ahead = TRUE, time_unit = "week"))
     Condition
       Error in `create_target_metadata()`:

--- a/tests/testthat/test-create_target_metadata.R
+++ b/tests/testthat/test-create_target_metadata.R
@@ -62,7 +62,7 @@ test_that("create_target_metadata functions error correctly", {
         time_unit = "week"
       ),
       create_target_metadata_item(
-        target_id = "inc death",
+        target_id = "inc hosp",
         target_name = "Weekly incident influenza deaths",
         target_units = "rate per 100,000 population",
         target_keys = list(target = "inc hosp"),
@@ -113,7 +113,7 @@ test_that("create_target_metadata functions error correctly", {
             target_id = "inc death",
             target_name = "Weekly incident influenza deaths",
             target_units = "rate per 100,000 population",
-            target_keys = list(target = "inc hosp"),
+            target_keys = list(target = "inc death"),
             target_type = "discrete",
             is_step_ahead = TRUE,
             time_unit = "week"

--- a/tests/testthat/test-create_target_metadata_item.R
+++ b/tests/testthat/test-create_target_metadata_item.R
@@ -212,3 +212,53 @@ test_that("Target_keys of length more than 1 are not allowed post v5.0.0", {
     }
   )
 })
+
+test_that("target_ids and target_key values mismatches detected correctly", {
+  skip_if_offline()
+  expect_error(
+    create_target_metadata_item(
+      target_id = "inc hosp",
+      target_name = "Weekly incident influenza hospitalizations",
+      target_units = "rate per 100,000 population",
+      target_keys = list(target = "inc hospitalizations"),
+      target_type = "discrete",
+      is_step_ahead = TRUE,
+      time_unit = "week"
+    ),
+    regexp = ".*target_id.* value .* does not match corresponding .*target_keys.* value"
+  )
+
+  expect_s3_class(
+    create_target_metadata_item(
+      target_id = "inc hosp",
+      target_name = "Weekly incident influenza hospitalizations",
+      target_units = "rate per 100,000 population",
+      target_keys = NULL,
+      target_type = "discrete",
+      is_step_ahead = TRUE,
+      time_unit = "week"
+    ),
+    "target_metadata_item"
+  )
+
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v4.0.0"
+    ),
+    {
+      target_metadata <- create_target_metadata_item(
+        target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations",
+        target_units = "rate per 100,000 population",
+        target_keys = list(
+          target_variable = "inc",
+          target_outcome = " hospitalizations"
+        ),
+        target_type = "discrete",
+        is_step_ahead = TRUE,
+        time_unit = "week"
+      )
+      expect_s3_class(target_metadata, "target_metadata_item")
+    }
+  )
+})

--- a/tests/testthat/test-validate-config-utils.R
+++ b/tests/testthat/test-validate-config-utils.R
@@ -1,0 +1,103 @@
+test_that("val_target_ids_match_target_key_values works", {
+  # Ensure validation returns mismatches between target IDs and target keys
+  # correctly when multiple target keys are present.
+  grp_target_keys <- jsonlite::read_json(
+    testthat::test_path("testdata/target-metadata-target-id-target-key-mismatch.json"),
+    simplifyVector = TRUE,
+    simplifyDataFrame = FALSE
+  )$target_metadata
+  model_task_i <- 1L
+  round_i <- 1L
+
+  schema <- hubUtils::get_schema(hubUtils::get_schema_url(version = "v5.0.0"))
+
+  check <- val_target_ids_match_target_key_values(
+    grp_target_keys, model_task_i, round_i, schema
+  )
+  expect_equal(
+    check,
+    structure(
+      list(
+        instancePath = structure(
+          c(
+            "/rounds/0/model_tasks/0/target_metadata/1/target_id",
+            "/rounds/0/model_tasks/0/target_metadata/2/target_id"
+          ),
+          class = c(
+            "glue",
+            "character"
+          )
+        ),
+        schemaPath = c(
+          "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata/items/properties/target_id", # nolint: line_length_linter
+          "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata/items/properties/target_id" # nolint: line_length_linter
+        ),
+        keyword = c("target_id value", "target_id value"),
+        message = c(
+          "target_id value does not match corresponding target key value",
+          "target_id value does not match corresponding target key value"
+        ),
+        schema = c("", ""),
+        data = structure(
+          c(
+            "target_id value: 'ili-ed-hosp';\ntarget_key.target value: 'ILI ED hospitalisation'",
+            "target_id value: 'ili-ed-visits';\ntarget_key.target value: 'ILI ED visits'"
+          ),
+          class = c("glue", "character")
+        )
+      ),
+      class = "data.frame",
+      row.names = c(
+        NA,
+        -2L
+      )
+    )
+  )
+
+  # Ensure validation returns mismatches between target IDs and target keys
+  # correctly when a single target keys are present.
+  grp_target_keys <- grp_target_keys[2]
+  check <- val_target_ids_match_target_key_values(
+    grp_target_keys, model_task_i, round_i, schema
+  )
+  expect_equal(
+    check,
+    structure(
+      list(
+        instancePath = structure(
+          "/rounds/0/model_tasks/0/target_metadata/0/target_id",
+          class = c("glue", "character")
+        ),
+        schemaPath =
+          "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata/items/properties/target_id", # nolint: line_length_linter
+        keyword = "target_id value",
+        message = "target_id value does not match corresponding target key value",
+        schema = "",
+        data = structure(
+          "target_id value: 'ili-ed-hosp';\ntarget_key.target value: 'ILI ED hospitalisation'",
+          class = c("glue", "character")
+        )
+      ),
+      class = "data.frame", row.names = c(NA, -1L)
+    )
+  )
+
+  # Ensure validation returns NULL when target keys are NULL
+  grp_target_keys[[1]]$target_keys <- NULL
+  check <- val_target_ids_match_target_key_values(
+    grp_target_keys, model_task_i, round_i, schema
+  )
+  expect_null(check)
+
+  # Ensure validation returns NULL when target keys are spread across multiple
+  # task IDs
+  schema <- hubUtils::get_schema(hubUtils::get_schema_url(version = "v3.0.0"))
+  grp_target_keys[[1]]$target_keys <- list(
+    target_variable = "ILI ED",
+    target_outcome = "hospitalisation"
+  )
+  check <- val_target_ids_match_target_key_values(
+    grp_target_keys, model_task_i, round_i, schema
+  )
+  expect_null(check)
+})

--- a/tests/testthat/testdata/target-metadata-target-id-target-key-mismatch.json
+++ b/tests/testthat/testdata/target-metadata-target-id-target-key-mismatch.json
@@ -1,0 +1,40 @@
+{
+                        "target_metadata": [
+                        {
+                            "target_id": "ili-ed-deaths",
+                            "target_name": "ED ili-ed-deaths due to ILI",
+                            "target_units": "count",
+                            "target_keys": {
+                                "target": "ili-ed-deaths"
+                            },
+                            "target_type": "continuous",
+                            "description": "This target represents the count of ED deaths due to ILI in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        },
+                        {
+                            "target_id": "ili-ed-hosp",
+                            "target_name": "ED hospitalisations due to ILI",
+                            "target_units": "count",
+                            "target_keys": {
+                                "target": "ILI ED hospitalisation"
+                            },
+                            "target_type": "continuous",
+                            "description": "This target represents the count of ED hospitalisations due to ILI in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        },
+                        {
+                            "target_id": "ili-ed-visits",
+                            "target_name": "ED visits due to ILI",
+                            "target_units": "count",
+                            "target_keys": {
+                                "target": "ILI ED visits"
+                            },
+                            "target_type": "continuous",
+                            "description": "This target represents the count of ED visits due to ILI in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",
+                            "is_step_ahead": true,
+                            "time_unit": "week"
+                        }
+                    ]
+}


### PR DESCRIPTION
This PR resolves #102  by validating that `target_id` `target_metadata` item properties match the corresponding `target_key` value.

Note that this check is not implemented if the `target_key`s are `NULL` or when the length of `target_key`s property does not equal the length of the `target_id`(which is always 1L. This is to account for earlier schema versions where target keys were allowed to be spread across multiple task IDs. Because this complicates this check, it is just skipped in when the length of target key values is not 1L.

Note as well that we already have checks that ensure target keys are valid target task ID values . Consequently, the addition of this new check also ensures `target_id`s represent valid target task ID values.