### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to `hubAdmin`.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -14,7 +14,7 @@
 #' model outputs and can take values of `"auto"`, `"character"`, `"double"`,
 #' `"integer"`, `"logical"`, or `"Date"`.
 #' For more details consult the [hubDocs documentation on model output datatypes](
-#' https://hubverse.io/en/latest/user-guide/model-output.html#the-importance-of-a-stable-model-output-file-schema)
+#' https://docs.hubverse.io/en/latest/user-guide/model-output.html#the-importance-of-a-stable-model-output-file-schema)
 #' @param derived_task_ids character vector of derived task id names (i.e. task IDs
 #' whose values are depended on the values of other task IDs). Only available for
 #' schema version v4.0.0 and later.
@@ -24,7 +24,7 @@
 #' @seealso [create_rounds()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' rounds <- create_rounds(

--- a/R/create_output_type.R
+++ b/R/create_output_type.R
@@ -10,7 +10,7 @@
 #' [create_output_type_pmf()], [create_output_type_sample()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @examples
 #' create_output_type(
 #'   create_output_type_mean(

--- a/R/create_output_type_item.R
+++ b/R/create_output_type_item.R
@@ -13,7 +13,7 @@
 #'
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @return a named list of class `output_type_item` representing a `mean` or
 #' `median` output type.
 #' @inheritParams create_task_id
@@ -193,7 +193,7 @@ create_output_type_point <- function(output_type = c("mean", "median"),
 #' @inheritParams create_output_type_mean
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @return a named list of class `output_type_item` representing a `quantile`,
 #' `cdf`, `pmf` or `sample` output type.

--- a/R/create_round.R
+++ b/R/create_round.R
@@ -33,14 +33,14 @@
 #'  of file format in `admin.json`. For more details on whether this argument can
 #'  be used as well as available formats, please consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @inheritParams create_config
 #' @return a named list of class `round`.
 #' @export
 #' @seealso [create_rounds()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @examples
 #' model_tasks <- create_model_tasks(
 #'   create_model_task(

--- a/R/create_rounds.R
+++ b/R/create_rounds.R
@@ -8,7 +8,7 @@
 #' @seealso [create_round()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' model_tasks <- create_model_tasks(

--- a/R/create_target_metadata.R
+++ b/R/create_target_metadata.R
@@ -8,7 +8,7 @@
 #' @seealso [create_target_metadata_item()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' create_target_metadata(

--- a/R/create_target_metadata_item.R
+++ b/R/create_target_metadata_item.R
@@ -17,14 +17,14 @@
 #' The name of the element should match a `task_id` variable name within the same
 #' `model_tasks` object and the value should match a single value of that variable
 #' as described in
-#' [target metadata section of the official hubverse documentation](https://hubverse.io/en/latest/user-guide/tasks.html#target-metadata). # nolint: line_length_linter
+#' [target metadata section of the official hubverse documentation](https://docs.hubverse.io/en/latest/user-guide/tasks.html#target-metadata). # nolint: line_length_linter
 #' Otherwise, `NULL` in the case where the target is not specified as a task_id
 #' but is specified solely through the `target_id` argument.
 #' @param description character string (optional). An optional verbose description
 #' of the target that might include information such as definitions of a 'rate' or similar.
 #' @param target_type character string. Target statistical data type. Consult the
 #' [appropriate version of the hub schema](
-#' https://hubverse.io/en/latest/format/hub-metadata.html#model-tasks-tasks-json-interactive-schema)
+#' https://docs.hubverse.io/en/latest/format/hub-metadata.html#model-tasks-tasks-json-interactive-schema)
 #' for potential values.
 #' @param is_step_ahead logical. Whether the target is part of a sequence of values
 #' @param time_unit character string. If `is_step_ahead` is `TRUE`, then this
@@ -34,7 +34,7 @@
 #' @seealso [create_target_metadata()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #' @return a named list of class `target_metadata_item`.
 #' @export
 #'

--- a/R/create_task_id.R
+++ b/R/create_task_id.R
@@ -20,7 +20,7 @@
 #' @details `required` and `optional` vectors for standard task_ids defined in a Hub schema
 #' must match data types and formats specified in the schema. For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html)
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html)
 #'
 #' JSON schema data type names differ to those in R. Use the following mappings to
 #' create vectors of appropriate data types which will correspond to correct JSON

--- a/R/create_task_ids.R
+++ b/R/create_task_ids.R
@@ -7,7 +7,7 @@
 #' @seealso [create_task_id()]
 #' @details For more details consult
 #' the [documentation on `tasks.json` Hub config files](
-#' https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
+#' https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html).
 #'
 #' @examples
 #' create_task_ids(

--- a/R/view_config_val_errors.R
+++ b/R/view_config_val_errors.R
@@ -382,6 +382,6 @@ render_errors_df <- function(error_df) {
     ) %>%
     gt::tab_source_note(
       source_note = gt::md("For more information, please consult the
-                                 [**`hubDocs` documentation**.](https://hubverse.io/en/latest/)")
+                                 [**`hubDocs` documentation**.](https://docs.hubverse.io/en/latest/)")
     )
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -26,7 +26,7 @@ knitr::opts_chunk$set(
 
 The goal of hubAdmin is to provide a set of utility functions for administering hubverse Hubs.
 
-This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
+This package is part of the [hubverse](https://hubverse.io) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
 
 ## Installation
 
@@ -61,6 +61,6 @@ Please note that the hubAdmin package is released with a [Contributor Code of Co
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubAdmin package](.github/CONTRIBUTING.md).
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubAdmin package](.github/CONTRIBUTING.md).
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ status](https://www.r-pkg.org/badges/version/hubAdmin)](https://CRAN.R-project.o
 The goal of hubAdmin is to provide a set of utility functions for
 administering hubverse Hubs.
 
-This package is part of the [hubverse](https://hubverse.io/en/latest/)
+This package is part of the [hubverse](https://hubverse.io)
 ecosystem, which aims to provide a set of tools for infectious disease
 modeling hubs to share and collaborate on their work.
 
@@ -64,5 +64,5 @@ project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html) or
+Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or
 [how to contribute to the hubAdmin package](.github/CONTRIBUTING.md).

--- a/man/create_config.Rd
+++ b/man/create_config.Rd
@@ -17,7 +17,7 @@ schema version used for the config is <= v3.0.1.
 This property is used to set the data type of the \code{output_type_id} column in
 model outputs and can take values of \code{"auto"}, \code{"character"}, \code{"double"},
 \code{"integer"}, \code{"logical"}, or \code{"Date"}.
-For more details consult the \href{https://hubverse.io/en/latest/user-guide/model-output.html#the-importance-of-a-stable-model-output-file-schema}{hubDocs documentation on model output datatypes}}
+For more details consult the \href{https://docs.hubverse.io/en/latest/user-guide/model-output.html#the-importance-of-a-stable-model-output-file-schema}{hubDocs documentation on model output datatypes}}
 
 \item{derived_task_ids}{character vector of derived task id names (i.e. task IDs
 whose values are depended on the values of other task IDs). Only available for
@@ -32,7 +32,7 @@ class \code{config}. This can be written out to a \code{tasks.json} file.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 rounds <- create_rounds(

--- a/man/create_output_type.Rd
+++ b/man/create_output_type.Rd
@@ -18,7 +18,7 @@ Create an \code{output_type} class object.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_output_type(

--- a/man/create_output_type_mean.Rd
+++ b/man/create_output_type_mean.Rd
@@ -58,7 +58,7 @@ or appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \section{Functions}{
 \itemize{

--- a/man/create_output_type_quantile.Rd
+++ b/man/create_output_type_quantile.Rd
@@ -106,7 +106,7 @@ or appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \section{Functions}{
 \itemize{

--- a/man/create_round.Rd
+++ b/man/create_round.Rd
@@ -55,7 +55,7 @@ This option in only available for some versions of the schema and is ignored if
 not allowed in the version of the schema used. It also overrides any specification
 of file format in \code{admin.json}. For more details on whether this argument can
 be used as well as available formats, please consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.}
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.}
 
 \item{derived_task_ids}{character vector of derived task id names (i.e. task IDs
 whose values are depended on the values of other task IDs). Only available for
@@ -73,7 +73,7 @@ appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 model_tasks <- create_model_tasks(

--- a/man/create_rounds.Rd
+++ b/man/create_rounds.Rd
@@ -18,7 +18,7 @@ Create a \code{rounds} class object.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 model_tasks <- create_model_tasks(

--- a/man/create_target_metadata.Rd
+++ b/man/create_target_metadata.Rd
@@ -18,7 +18,7 @@ Create a \code{target_metadata} class object.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_target_metadata(

--- a/man/create_target_metadata_item.Rd
+++ b/man/create_target_metadata_item.Rd
@@ -32,7 +32,7 @@ Should be a named list containing a single character string element.
 The name of the element should match a \code{task_id} variable name within the same
 \code{model_tasks} object and the value should match a single value of that variable
 as described in
-\href{https://hubverse.io/en/latest/user-guide/tasks.html#target-metadata}{target metadata section of the official hubverse documentation}. # nolint: line_length_linter
+\href{https://docs.hubverse.io/en/latest/user-guide/tasks.html#target-metadata}{target metadata section of the official hubverse documentation}. # nolint: line_length_linter
 Otherwise, \code{NULL} in the case where the target is not specified as a task_id
 but is specified solely through the \code{target_id} argument.}
 
@@ -40,7 +40,7 @@ but is specified solely through the \code{target_id} argument.}
 of the target that might include information such as definitions of a 'rate' or similar.}
 
 \item{target_type}{character string. Target statistical data type. Consult the
-\href{https://hubverse.io/en/latest/format/hub-metadata.html#model-tasks-tasks-json-interactive-schema}{appropriate version of the hub schema}
+\href{https://docs.hubverse.io/en/latest/format/hub-metadata.html#model-tasks-tasks-json-interactive-schema}{appropriate version of the hub schema}
 for potential values.}
 
 \item{is_step_ahead}{logical. Whether the target is part of a sequence of values}
@@ -74,7 +74,7 @@ appended to \code{tasks.json} Hub config files.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_target_metadata_item(

--- a/man/create_task_id.Rd
+++ b/man/create_task_id.Rd
@@ -47,7 +47,7 @@ appended to \code{tasks.json} Hub config files.
 \details{
 \code{required} and \code{optional} vectors for standard task_ids defined in a Hub schema
 must match data types and formats specified in the schema. For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}
 
 JSON schema data type names differ to those in R. Use the following mappings to
 create vectors of appropriate data types which will correspond to correct JSON

--- a/man/create_task_ids.Rd
+++ b/man/create_task_ids.Rd
@@ -17,7 +17,7 @@ Create a \code{task_ids} class object.
 }
 \details{
 For more details consult
-the \href{https://hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
+the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.html}{documentation on \code{tasks.json} Hub config files}.
 }
 \examples{
 create_task_ids(

--- a/tests/_snaps/view_config_val_errors.md
+++ b/tests/_snaps/view_config_val_errors.md
@@ -4,7 +4,7 @@
       tbl$`_source_notes`
     Output
       [[1]]
-      [1] "For more information, please consult the\n                                 [**`hubDocs` documentation**.](https://hubverse.io/en/latest/)"
+      [1] "For more information, please consult the\n                                 [**`hubDocs` documentation**.](https://docs.hubverse.io/en/latest/)"
       attr(,"class")
       [1] "from_markdown"
       

--- a/tests/testthat/_snaps/view_config_val_errors.md
+++ b/tests/testthat/_snaps/view_config_val_errors.md
@@ -4,7 +4,7 @@
       tbl$`_source_notes`
     Output
       [[1]]
-      [1] "For more information, please consult the\n                                 [**`hubDocs` documentation**.](https://hubverse.io/en/latest/)"
+      [1] "For more information, please consult the\n                                 [**`hubDocs` documentation**.](https://docs.hubverse.io/en/latest/)"
       attr(,"class")
       [1] "from_markdown"
       

--- a/vignettes/articles/scripting-tasks-config.Rmd
+++ b/vignettes/articles/scripting-tasks-config.Rmd
@@ -87,7 +87,7 @@ variable in `task_ids` so it can validate that the round IDs are unique.
 </div>
 
 These rounds contain one or more [**modeling
-tasks**](https://hubverse.io/en/latest/user-guide/tasks.html) that define the
+tasks**](https://docs.hubverse.io/en/latest/user-guide/tasks.html) that define the
 expected content of a model submission against one or more modeling targets.
 Each modeling task includes three properties:
 
@@ -320,7 +320,7 @@ column of a model submission output type id should be. This is important for
 downstream analysis and visualization of the data. This is automatically
 determined by default, but **it is [important to maintain a stable output type
 ID column data
-type](https://hubverse.io/en/latest/user-guide/model-output.html#the-importance-of-a-stable-model-output-file-schema)
+type](https://docs.hubverse.io/en/latest/user-guide/model-output.html#the-importance-of-a-stable-model-output-file-schema)
 throughout the life of your hub.** The consequences of not doing so could lead
 to an inability to evaluate past submissions. For example, this hub has
 quantile values, so the default would set the value of the `output_type_id`


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.