### PR TITLE
Set versioned property globally in example target-data.json config

### DIFF
--- a/tests/testthat/testdata/v6-target-data-valid.json
+++ b/tests/testthat/testdata/v6-target-data-valid.json
@@ -5,12 +5,12 @@
     "location"
   ],
   "date_col": "target_end_date",
+  "versioned": true,
   "time-series": {
     "non_task_id_schema": {
       "location_name": "character",
       "target_end_date": "Date"
-    },
-    "versioned": true
+    }
   },
   "oracle-output": {
     "has_output_type_ids": true,


### PR DESCRIPTION
Following the [updates to the target-data.json proposal](https://github.com/reichlab/decisions/pull/33), namely the standardisation of configuration hierarchy of properties, and related updates to the [schema](https://github.com/hubverse-org/schemas/pull/135/commits/5eb12428327f044f17be920922d35710965b9445) and [`hubUtils`](https://github.com/hubverse-org/hubUtils/pull/255), this PR:
1. Updates the example valid v6 target-data.json file to use global `versioned` setting.
2. Demonstrates that all tests still pass