### PR TITLE
Add `additional_metadata` support for Schema v6.0.0 in relevant `create_*` fns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # hubAdmin (development version)
 
+* Added support for additional properties via `...` argument in `create_round()` and updated both `create_round()` and `create_target_metadata_item()` to support schema v6.0.0 `additional_metadata` field. In v6.0.0+, additional properties are wrapped in an `additional_metadata` field. For earlier versions: `create_round()` adds properties directly to the round object (note: while the schema has always allowed additional properties in rounds, the programmatic functionality was previously missing); `create_target_metadata_item()` adds properties directly for v5.1.0+ or ignores them with a message for earlier versions.
+
 # hubAdmin 1.8.0
 
 * Added basic tests for v6.0.0 schema (#127).

--- a/man/create_round.Rd
+++ b/man/create_round.Rd
@@ -12,7 +12,8 @@ create_round(
   submissions_due,
   last_data_date = NULL,
   file_format = NULL,
-  derived_task_ids = NULL
+  derived_task_ids = NULL,
+  ...
 )
 }
 \arguments{
@@ -60,6 +61,10 @@ the \href{https://docs.hubverse.io/en/latest/quickstart-hub-admin/tasks-config.h
 \item{derived_task_ids}{character vector of derived task id names (i.e. task IDs
 whose values are depended on the values of other task IDs). Only available for
 schema version v4.0.0 and later.}
+
+\item{...}{additional optional properties to add to the round list output.
+In schema versions greater or equal to v6.0.0, these properties are placed in
+the \code{additional_metadata} field.}
 }
 \value{
 a named list of class \code{round}.
@@ -126,6 +131,20 @@ create_round(
     end = 2L
   ),
   last_data_date = "2023-01-02"
+)
+# For schema version >= v6.0.0, example with an additional optional property
+create_round(
+  round_id_from_variable = TRUE,
+  round_id = "origin_date",
+  model_tasks = model_tasks,
+  submissions_due = list(
+    relative_to = "origin_date",
+    start = -4L,
+    end = 2L
+  ),
+  last_data_date = "2023-01-02",
+  round_label = "Round 1",
+  data_source = "https://example.com/data"
 )
 }
 \seealso{

--- a/man/create_target_metadata_item.Rd
+++ b/man/create_target_metadata_item.Rd
@@ -64,7 +64,8 @@ option "hubAdmin.branch".}
 
 \item{...}{additional optional properties to add to the target metadata list
 output. Only available for schema version equal or greater than v5.1.0,
-ignored for past version.}
+ignored for past version. In schema versions greater or equal to v6.0.0,
+these properties are placed in the \code{additional_properties} field.}
 }
 \value{
 a named list of class \code{target_metadata_item}.
@@ -100,7 +101,7 @@ create_target_metadata_item(
   target_type = "discrete",
   is_step_ahead = TRUE,
   time_unit = "week",
-  uri = "https://ontobee.org/"
+  uri = "http://purl.obolibrary.org/obo/IDO_0000463"
 )
 options(hubAdmin.schema_version = "v3.0.1")
 create_target_metadata_item(

--- a/tests/testthat/test-create_round.R
+++ b/tests/testthat/test-create_round.R
@@ -3,7 +3,8 @@ test_that("create_round functions work correctly", {
   model_tasks <- create_model_tasks(
     create_model_task(
       task_ids = create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -11,14 +12,12 @@ test_that("create_round functions work correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("location",
+        create_task_id(
+          "location",
           required = "US",
           optional = c("01", "02", "04", "05", "06")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       ),
       output_type = create_output_type(
         create_output_type_mean(
@@ -50,7 +49,8 @@ test_that("create_round functions work correctly", {
         end = "2023-01-18"
       ),
       last_data_date = "2023-01-02"
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
   expect_snapshot(
     create_round(
@@ -63,7 +63,8 @@ test_that("create_round functions work correctly", {
         end = 2L
       ),
       last_data_date = "2023-01-02"
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 })
 
@@ -73,7 +74,8 @@ test_that("create_round name matching works correctly", {
   model_tasks <- create_model_tasks(
     create_model_task(
       task_ids = create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -81,14 +83,12 @@ test_that("create_round name matching works correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("location",
+        create_task_id(
+          "location",
           required = "US",
           optional = c("01", "02", "04", "05", "06")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       ),
       output_type = create_output_type(
         create_output_type_mean(
@@ -252,7 +252,8 @@ test_that("validating round_id patterns when round_id_from_var = TRUE works", {
       )
       # Check that valid round_id values are accepted
       task_ids <- create_task_ids(
-        create_task_id("round_id_var",
+        create_task_id(
+          "round_id_var",
           required = "2023-01-09",
           optional = c(
             "2023-01-02",
@@ -283,7 +284,8 @@ test_that("validating round_id patterns when round_id_from_var = TRUE works", {
       # Check that multiple invalid values in both required and optional values
       # reported correctly
       task_ids <- create_task_ids(
-        create_task_id("round_id_var",
+        create_task_id(
+          "round_id_var",
           required = "invalid-round-id-req",
           optional = c(
             "2023-01-02",
@@ -317,7 +319,8 @@ test_that("validating round_id patterns when round_id_from_var = TRUE works", {
       # Check that multiple invalid values in required or optional values
       # across multiple modeling tasks reported correctly
       task_ids_1 <- create_task_ids(
-        create_task_id("round_id_var",
+        create_task_id(
+          "round_id_var",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -328,7 +331,8 @@ test_that("validating round_id patterns when round_id_from_var = TRUE works", {
         )
       )
       task_ids_2 <- create_task_ids(
-        create_task_id("round_id_var",
+        create_task_id(
+          "round_id_var",
           required = c(
             "2023-01-02",
             "24_25_covid",
@@ -395,7 +399,8 @@ test_that("validating round_id pattern when round_id_from_var = FALSE works", {
       # Check that valid round_id value is accepted while round_id_var invalid
       # values are ignored
       task_ids <- create_task_ids(
-        create_task_id("round_id_var",
+        create_task_id(
+          "round_id_var",
           required = "2023-01-09",
           optional = c(
             "2023-01-02",
@@ -437,7 +442,8 @@ test_that("validating round_id pattern when round_id_from_var = FALSE works", {
 
       # Check that invalid `round_id` reported correctly
       task_ids <- create_task_ids(
-        create_task_id("round_id_var",
+        create_task_id(
+          "round_id_var",
           required = "invalid-round-id-req",
           optional = c(
             "2023-01-02",
@@ -467,6 +473,187 @@ test_that("validating round_id pattern when round_id_from_var = FALSE works", {
         ),
         error = TRUE
       )
+    }
+  )
+})
+
+test_that("additional_metadata field for optional properties in v6.0.0+", {
+  # Create shared model_tasks for tests
+  model_tasks <- create_model_tasks(
+    create_model_task(
+      task_ids = create_task_ids(
+        create_task_id(
+          "origin_date",
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
+        ),
+        create_task_id(
+          "location",
+          required = "US",
+          optional = c("01", "02", "04", "05", "06")
+        ),
+        create_task_id("horizon", required = 1L, optional = 2:4)
+      ),
+      output_type = create_output_type(
+        create_output_type_mean(
+          is_required = TRUE,
+          value_type = "double",
+          value_minimum = 0L
+        )
+      ),
+      target_metadata = create_target_metadata(
+        create_target_metadata_item(
+          target_id = "inc hosp",
+          target_name = "Weekly incident influenza hospitalizations",
+          target_units = "rate per 100,000 population",
+          target_keys = NULL,
+          target_type = "discrete",
+          is_step_ahead = TRUE,
+          time_unit = "week"
+        )
+      )
+    )
+  )
+
+  # Test v6.0.0+ wraps additional properties in additional_metadata field
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v6.0.0"
+    ),
+    {
+      v6_with_additional <- create_round(
+        round_id_from_variable = TRUE,
+        round_id = "origin_date",
+        model_tasks = model_tasks,
+        submissions_due = list(
+          relative_to = "origin_date",
+          start = -4L,
+          end = 2L
+        ),
+        last_data_date = "2023-01-02",
+        round_label = "Round 1",
+        data_source = "https://example.com/data",
+        custom_field = "custom_value"
+      )
+
+      # Check that additional_metadata field exists
+      expect_true("additional_metadata" %in% names(v6_with_additional))
+
+      # Check that additional properties are nested within additional_metadata
+      expect_equal(
+        v6_with_additional$additional_metadata,
+        list(
+          round_label = "Round 1",
+          data_source = "https://example.com/data",
+          custom_field = "custom_value"
+        )
+      )
+
+      # Check that individual properties are NOT directly in the object
+      expect_false("round_label" %in% names(v6_with_additional))
+      expect_false("data_source" %in% names(v6_with_additional))
+      expect_false("custom_field" %in% names(v6_with_additional))
+
+      # Check the names attribute includes additional_metadata
+      expect_true("additional_metadata" %in% attr(v6_with_additional, "names"))
+    }
+  )
+
+  # Test v6.0.0+ without additional properties
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v6.0.0"
+    ),
+    {
+      v6_no_additional <- create_round(
+        round_id_from_variable = TRUE,
+        round_id = "origin_date",
+        model_tasks = model_tasks,
+        submissions_due = list(
+          relative_to = "origin_date",
+          start = -4L,
+          end = 2L
+        ),
+        last_data_date = "2023-01-02"
+      )
+
+      # Should not have additional_metadata field when no additional properties
+      expect_false("additional_metadata" %in% names(v6_no_additional))
+    }
+  )
+})
+
+test_that("additional properties pre-v6.0.0 are stored at tope level of object", {
+  # Pre-v6.0.0 - properties added directly
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v3.0.1"
+    ),
+    {
+      model_tasks_v3 <- create_model_tasks(
+        create_model_task(
+          task_ids = create_task_ids(
+            create_task_id(
+              "origin_date",
+              required = NULL,
+              optional = c(
+                "2023-01-02",
+                "2023-01-09",
+                "2023-01-16"
+              )
+            ),
+            create_task_id(
+              "location",
+              required = "US",
+              optional = c("01", "02", "04", "05", "06")
+            ),
+            create_task_id("horizon", required = 1L, optional = 2:4)
+          ),
+          output_type = create_output_type(
+            create_output_type_mean(
+              is_required = TRUE,
+              value_type = "double",
+              value_minimum = 0L
+            )
+          ),
+          target_metadata = create_target_metadata(
+            create_target_metadata_item(
+              target_id = "inc hosp",
+              target_name = "Weekly incident influenza hospitalizations",
+              target_units = "rate per 100,000 population",
+              target_keys = NULL,
+              target_type = "discrete",
+              is_step_ahead = TRUE,
+              time_unit = "week"
+            )
+          )
+        )
+      )
+
+      pre_v6_round <- create_round(
+        round_id_from_variable = TRUE,
+        round_id = "origin_date",
+        model_tasks = model_tasks_v3,
+        submissions_due = list(
+          relative_to = "origin_date",
+          start = -4L,
+          end = 2L
+        ),
+        last_data_date = "2023-01-02",
+        round_label = "Round 1",
+        custom_field = "custom_value"
+      )
+
+      # In pre-v6.0.0, properties are directly in the object
+      expect_true("round_label" %in% names(pre_v6_round))
+      expect_true("custom_field" %in% names(pre_v6_round))
+      expect_false("additional_metadata" %in% names(pre_v6_round))
+      expect_equal(pre_v6_round$round_label, "Round 1")
+      expect_equal(pre_v6_round$custom_field, "custom_value")
     }
   )
 })

--- a/tests/testthat/test-create_target_metadata_item.R
+++ b/tests/testthat/test-create_target_metadata_item.R
@@ -9,7 +9,8 @@ test_that("create_target_metadata_item functions work correctly", {
       target_type = "discrete",
       is_step_ahead = TRUE,
       time_unit = "week"
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
   expect_snapshot(
     create_target_metadata_item(
@@ -18,10 +19,10 @@ test_that("create_target_metadata_item functions work correctly", {
       target_units = "rate per 100,000 population",
       target_type = "discrete",
       is_step_ahead = FALSE
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 })
-
 
 
 test_that("create_target_metadata_item functions error correctly", {
@@ -114,7 +115,8 @@ test_that("schema version option works for create_target_metadata_item", {
     target_type = "discrete",
     is_step_ahead = TRUE,
     time_unit = "week"
-  ) |> verify_latest_schema_version()
+  ) |>
+    verify_latest_schema_version()
 
   arg_version <- create_target_metadata_item(
     target_id = "inc hosp",
@@ -288,7 +290,7 @@ test_that("possibility to add optional properties starting v5.1.0", {
         target_type = "discrete",
         is_step_ahead = TRUE,
         time_unit = "week",
-        uri = "https://ontobee.org/",
+        uri = "http://purl.obolibrary.org/obo/IDO_0000463",
         alternative_name = "Incident Hospitalization"
       )
     }
@@ -309,11 +311,137 @@ test_that("possibility to add optional properties starting v5.1.0", {
           target_type = "discrete",
           is_step_ahead = TRUE,
           time_unit = "week",
-          uri = "https://ontobee.org/",
+          uri = "http://purl.obolibrary.org/obo/IDO_0000463",
           alternative_name = "Incident Hospitalization"
         )
       )
     }
   )
   expect_equal(names(no_opt), names(opt_version))
+})
+
+test_that("additional_metadata field for optional properties in v6.0.0+", {
+  # Test v6.0.0+ wraps additional properties in additional_metadata field
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v6.0.0"
+    ),
+    {
+      v6_with_additional <- create_target_metadata_item(
+        target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations",
+        target_units = "rate per 100,000 population",
+        target_keys = list(target = "inc hosp"),
+        target_type = "discrete",
+        is_step_ahead = TRUE,
+        time_unit = "week",
+        uri = "http://purl.obolibrary.org/obo/IDO_0000463",
+        alternative_name = "Incident Hospitalization",
+        custom_field = "custom_value"
+      )
+
+      # Check that additional_metadata field exists
+      expect_true("additional_metadata" %in% names(v6_with_additional))
+
+      # Check that additional properties are nested within additional_metadata
+      expect_equal(
+        v6_with_additional$additional_metadata,
+        list(
+          uri = "http://purl.obolibrary.org/obo/IDO_0000463",
+          alternative_name = "Incident Hospitalization",
+          custom_field = "custom_value"
+        )
+      )
+
+      # Check that individual properties are NOT directly in the object
+      expect_false("uri" %in% names(v6_with_additional))
+      expect_false("alternative_name" %in% names(v6_with_additional))
+      expect_false("custom_field" %in% names(v6_with_additional))
+
+      # Check the names attribute includes additional_metadata
+      expect_true("additional_metadata" %in% attr(v6_with_additional, "names"))
+    }
+  )
+
+  # Test v6.0.0+ without additional properties
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v6.0.0"
+    ),
+    {
+      v6_no_additional <- create_target_metadata_item(
+        target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations",
+        target_units = "rate per 100,000 population",
+        target_keys = list(target = "inc hosp"),
+        target_type = "discrete",
+        is_step_ahead = TRUE,
+        time_unit = "week"
+      )
+
+      # Should not have additional_metadata field when no additional properties
+      expect_false("additional_metadata" %in% names(v6_no_additional))
+    }
+  )
+})
+
+test_that("additional properties behavior differs between v5.1.0 and v6.0.0", {
+  skip_if_offline()
+
+  # v5.1.0 - properties added directly
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v5.1.0"
+    ),
+    {
+      v5_item <- create_target_metadata_item(
+        target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations",
+        target_units = "rate per 100,000 population",
+        target_keys = list(target = "inc hosp"),
+        target_type = "discrete",
+        is_step_ahead = TRUE,
+        time_unit = "week",
+        uri = "http://purl.obolibrary.org/obo/IDO_0000463",
+        custom_field = "custom_value"
+      )
+
+      # In v5.1.0, properties are directly in the object
+      expect_true("uri" %in% names(v5_item))
+      expect_true("custom_field" %in% names(v5_item))
+      expect_false("additional_metadata" %in% names(v5_item))
+      expect_equal(v5_item$uri, "http://purl.obolibrary.org/obo/IDO_0000463")
+      expect_equal(v5_item$custom_field, "custom_value")
+    }
+  )
+
+  # v6.0.0 - properties wrapped in additional_metadata
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v6.0.0"
+    ),
+    {
+      v6_item <- create_target_metadata_item(
+        target_id = "inc hosp",
+        target_name = "Weekly incident influenza hospitalizations",
+        target_units = "rate per 100,000 population",
+        target_keys = list(target = "inc hosp"),
+        target_type = "discrete",
+        is_step_ahead = TRUE,
+        time_unit = "week",
+        uri = "http://purl.obolibrary.org/obo/IDO_0000463",
+        custom_field = "custom_value"
+      )
+
+      # In v6.0.0, properties are nested in additional_metadata
+      expect_false("uri" %in% names(v6_item))
+      expect_false("custom_field" %in% names(v6_item))
+      expect_true("additional_metadata" %in% names(v6_item))
+      expect_equal(
+        v6_item$additional_metadata$uri,
+        "http://purl.obolibrary.org/obo/IDO_0000463"
+      )
+      expect_equal(v6_item$additional_metadata$custom_field, "custom_value")
+    }
+  )
 })

--- a/tests/testthat/test-validate_config.R
+++ b/tests/testthat/test-validate_config.R
@@ -619,3 +619,165 @@ test_that("Target data config validation errors with schema versions earlier tha
     regexp = 'Cannot validate `target-data.json` files using schema .*"v5.0.0"'
   )
 })
+
+test_that("Config with additional properties in v5.1.0 validates successfully", {
+  # Create a complete config with additional properties in both round and target_metadata
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v5.1.0"
+    ),
+    {
+      config <- create_config(
+        rounds = create_rounds(
+          create_round(
+            round_id_from_variable = FALSE,
+            round_id = "2023-01-02",
+            model_tasks = create_model_tasks(
+              create_model_task(
+                task_ids = create_task_ids(
+                  create_task_id(
+                    "origin_date",
+                    required = NULL,
+                    optional = c(
+                      "2023-01-02",
+                      "2023-01-09",
+                      "2023-01-16"
+                    )
+                  ),
+                  create_task_id(
+                    "location",
+                    required = "US",
+                    optional = c("01", "02", "04", "05", "06")
+                  ),
+                  create_task_id("horizon", required = 1L, optional = 2:4)
+                ),
+                output_type = create_output_type(
+                  create_output_type_mean(
+                    is_required = TRUE,
+                    value_type = "double",
+                    value_minimum = 0L
+                  )
+                ),
+                target_metadata = create_target_metadata(
+                  create_target_metadata_item(
+                    target_id = "inc hosp",
+                    target_name = "Weekly incident influenza hospitalizations",
+                    target_units = "rate per 100,000 population",
+                    target_keys = NULL,
+                    target_type = "discrete",
+                    is_step_ahead = TRUE,
+                    time_unit = "week",
+                    uri = "http://purl.obolibrary.org/obo/IDO_0000463",
+                    description_url = "https://example.com/target-description"
+                  )
+                )
+              )
+            ),
+            submissions_due = list(
+              start = "2023-01-05",
+              end = "2023-01-07"
+            ),
+            round_label = "Round 1",
+            data_source_url = "https://example.com/data"
+          )
+        )
+      )
+
+      # Write to temporary directory
+      tmp_hub <- withr::local_tempdir()
+      fs::dir_create(file.path(tmp_hub, "hub-config"))
+      write_config(config, tmp_hub)
+
+      # Validate the written config (using version from config file)
+      result <- suppressMessages(validate_config(
+        hub_path = tmp_hub,
+        config = "tasks"
+      ))
+
+      expect_true(result)
+    }
+  )
+})
+
+test_that("Config with additional_metadata in v6.0.0 validates successfully", {
+  skip_if_offline()
+
+  # Create a complete config with additional properties in both round and target_metadata
+  withr::with_options(
+    list(
+      hubAdmin.schema_version = "v6.0.0"
+    ),
+    {
+      config <- create_config(
+        rounds = create_rounds(
+          create_round(
+            round_id_from_variable = FALSE,
+            round_id = "2023-01-02",
+            model_tasks = create_model_tasks(
+              create_model_task(
+                task_ids = create_task_ids(
+                  create_task_id(
+                    "origin_date",
+                    required = NULL,
+                    optional = c(
+                      "2023-01-02",
+                      "2023-01-09",
+                      "2023-01-16"
+                    )
+                  ),
+                  create_task_id(
+                    "location",
+                    required = "US",
+                    optional = c("01", "02", "04", "05", "06")
+                  ),
+                  create_task_id("horizon", required = 1L, optional = 2:4)
+                ),
+                output_type = create_output_type(
+                  create_output_type_mean(
+                    is_required = TRUE,
+                    value_type = "double",
+                    value_minimum = 0L
+                  )
+                ),
+                target_metadata = create_target_metadata(
+                  create_target_metadata_item(
+                    target_id = "inc hosp",
+                    target_name = "Weekly incident influenza hospitalizations",
+                    target_units = "rate per 100,000 population",
+                    target_keys = NULL,
+                    target_type = "discrete",
+                    is_step_ahead = TRUE,
+                    time_unit = "week",
+                    uri = "http://purl.obolibrary.org/obo/IDO_0000463",
+                    description_url = "https://example.com/target-description",
+                    custom_field = "custom_value"
+                  )
+                )
+              )
+            ),
+            submissions_due = list(
+              start = "2023-01-05",
+              end = "2023-01-07"
+            ),
+            round_label = "Round 1",
+            data_source_url = "https://example.com/data",
+            custom_round_field = "custom_round_value"
+          )
+        )
+      )
+
+      # Write to temporary directory
+      tmp_hub <- withr::local_tempdir()
+      fs::dir_create(file.path(tmp_hub, "hub-config"))
+      write_config(config, tmp_hub)
+
+      # Validate the written config (using version from config file)
+      result <- suppressMessages(validate_config(
+        hub_path = tmp_hub,
+        config = "tasks"
+      ))
+
+      expect_true(result)
+    }
+  )
+})


### PR DESCRIPTION
## Summary

Resolves #140

Adds support for schema v6.0.0's `additional_metadata` field structure and implements missing functionality for adding additional properties to round objects programmatically.

## Changes

### `create_round()`
- Added `...` parameter to accept additional properties
- While the schema has always allowed additional properties in rounds, the programmatic functionality was missing

### `create_target_metadata_item()` & `create_round()`
- Both functions now support v6.0.0's `additional_metadata` field structure
- **v6.0.0+**: Additional properties wrapped in `additional_metadata` field
- **Earlier versions**:
  - `create_round()`: Properties added directly to round object
  - `create_target_metadata_item()`: Properties added directly (v5.1.0+) or ignored with message (< v5.1.0)

### Implementation Details

- Both functions use `hubUtils::extract_schema_version()` to determine schema version and apply appropriate structure
- Maintains backward compatibility across all schema versions


### Testing

- Added comprehensive unit tests for both v5.1.0 and v6.0.0 behavior across both functions
- Added integration tests that create, write, and validate complete configs with additional properties in both rounds and target_metadata

