### PR TITLE
Validate date_col references Date type task ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Fixed bug that caused unhelpful validation errors when using custom task IDs (e.g., `reference_date`) as round ID variables with inconsistent values across model tasks in schema versions v4.0.0+.
 * Added support for additional properties via `...` argument in `create_round()` and updated both `create_round()` and `create_target_metadata_item()` to support schema v6.0.0 `additional_metadata` field. In v6.0.0+, additional properties are wrapped in an `additional_metadata` field. For earlier versions: `create_round()` adds properties directly to the round object (note: while the schema has always allowed additional properties in rounds, the programmatic functionality was previously missing); `create_target_metadata_item()` adds properties directly for v5.1.0+ or ignores them with a message for earlier versions.
 * `has_target_data_config()` has been moved to and is now re-exported from `hubUtils` for backward compatibility (#139).
+* Added dynamic validation check for `target-data.json` that ensures when `date_col` references a task ID, that task ID must be a Date type task ID (i.e., contains ISO 8601 date values) (#145).
 
 # hubAdmin 1.8.0
 

--- a/R/validate_config.R
+++ b/R/validate_config.R
@@ -243,6 +243,12 @@ perform_target_data_dynamic_validations <- function(validation) {
       schema,
       task_id_names
     ),
+    # date_col validation
+    validate_date_col_is_date_type(
+      config_json,
+      config_tasks,
+      schema
+    ),
     # Config-wide validations
     validate_unique_names_recursive(config_json, schema = schema)
   ) |>


### PR DESCRIPTION
## Summary

Adds dynamic validation for `target-data.json` to ensure that when `date_col` references a task ID, that task ID must be of type Date (contains ISO 8601 date values).

## Changes

- Add `validate_date_col_is_date_type()` validation function
- Add helper functions for determining task ID types (adapted from hubData):
  - `get_task_id_type()`, `get_task_id_values()`, `get_data_type()`, `test_iso_date()`
- Integrate validation into `perform_target_data_dynamic_validations()`
- Add test cases covering valid and invalid scenarios
- Remove duplicate `get_date_col()` function, use `hubUtils::get_date_col()` instead

## Validation Behavior

**Passes when:**
- `date_col` references a Date type task ID ✅
- `date_col` is not a task ID (separate column) ✅

**Fails when:**
- `date_col` references a non-Date task ID (e.g., character, integer) ❌

## Example Error Message

```
date_col references task ID 'location' which is of type 'character' but must be of type 'Date'.
```

## Follow-up Work

Helper functions for determining task ID types are temporarily duplicated from hubData. See #147 for migrating to use hubUtils versions once available.

Closes #145