### PR TITLE
Migrate to Air code formatting

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -18,3 +18,5 @@
 ^claude
 ^PLAN\.md$
 ^.claude$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,12 +34,54 @@ Our procedures for contributing bigger changes, code in particular, generally fo
 ### Code style
 
 - New code should follow the tidyverse [style guide](https://style.tidyverse.org).
-  You can use the [styler](https://CRAN.R-project.org/package=styler) package to apply these styles, but please don't restyle code that has nothing to do with your PR.
+  We use [Air](https://posit-dev.github.io/air/) for code formatting.
 
 - We use [roxygen2](https://cran.r-project.org/package=roxygen2), with [Markdown syntax](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd-formatting.html), for documentation.
 
 - We use [testthat](https://cran.r-project.org/package=testthat) for unit tests.
   Contributions with test cases included are easier to accept.
+
+#### Setting up Air
+
+The project contains configuration files (`air.toml`, `.vscode/`) that ensure formatting is scoped to this repository only—your personal projects remain unaffected.
+
+**Positron**
+
+Air ships built-in with Positron. The project settings are already configured, so format-on-save is enabled automatically when working in this repo.
+
+**VS Code**
+
+1. Install the [Air extension](https://marketplace.visualstudio.com/items?itemName=Posit.air-vscode)
+2. The project settings are already configured, so format-on-save is enabled automatically when working in this repo
+
+**RStudio (2024.12.0+)**
+
+RStudio requires manual setup. Note that RStudio does not support per-project settings, so these are global options.
+
+1. Install the Air CLI:
+   - macOS/Linux: `curl -LsSf https://github.com/posit-dev/air/releases/latest/download/air-installer.sh | sh`
+   - macOS (Homebrew): `brew install air`
+   - Windows: `powershell -ExecutionPolicy Bypass -c "irm https://github.com/posit-dev/air/releases/latest/download/air-installer.ps1 | iex"`
+
+2. In RStudio, go to **Tools > Global Options > Code > Formatting** and:
+   - Check "Use external formatter"
+   - Set "Reformat command:" to `{path/to/air} format` (find the path with `which air` on macOS/Linux)
+   - See the [RStudio setup guide](https://posit-dev.github.io/air/editor-rstudio.html) for more details
+
+3. Optionally, enable format-on-save globally:
+   - In the same settings pane, check "Format code on save"
+   - **Note:** This applies to all projects, not just hubverse repos
+
+4. If you prefer not to enable format-on-save globally, format manually before committing:
+   - Use **Code > Reformat Code** (Cmd/Ctrl+Shift+A) or right-click and select "Reformat Code"
+   - CI will check formatting on PRs and fail if code is not formatted
+
+**Command Line**
+
+Works from any terminal:
+- Format entire project: `air format .`
+- Check without modifying: `air format . --check`
+
 
 ## Code of Conduct
 

--- a/.github/workflows/format-check.yaml
+++ b/.github/workflows/format-check.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+name: format-check.yaml
+
+permissions: read-all
+
+jobs:
+  format-check:
+    name: format-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Air
+        uses: posit-dev/setup-air@63e80dedb6d275c94a3841e15e5ff8691e1ab237 # v1
+
+      - name: Check formatting
+        run: air format . --check
+

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "[r]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "Posit.air-vscode"
+    },
+    "[quarto]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "quarto.quarto"
+    }
+}

--- a/R/append_additional_properties.R
+++ b/R/append_additional_properties.R
@@ -47,11 +47,15 @@ get_config_paths <- function(config) {
 # Keep any config_paths that match an additional_property path. The "additionalProperty"
 # element in the path is treated like a wildcard. Paths are also transformed to schema
 # paths by adding "items" elements appropriately.
-keep_additional_property_config_paths <- function(additional_property, config_paths) {
+keep_additional_property_config_paths <- function(
+  additional_property,
+  config_paths
+) {
   purrr::keep(
     config_paths,
     ~ is_valid_additional_property(.x, additional_property)
-  ) |> purrr::map(~ add_items(.x, additional_property))
+  ) |>
+    purrr::map(~ add_items(.x, additional_property))
 }
 
 # Given an additionalProperty schema path, detect whether a config path is a

--- a/R/check_derived_task_ids.R
+++ b/R/check_derived_task_ids.R
@@ -1,7 +1,11 @@
 # Check that derived task ID vectors are valid task IDs and applicable to
 # the schema version.
-check_derived_task_ids <- function(derived_task_ids, rounds, model_tasks,
-                                   call = rlang::caller_env()) {
+check_derived_task_ids <- function(
+  derived_task_ids,
+  rounds,
+  model_tasks,
+  call = rlang::caller_env()
+) {
   rlang::check_exclusive(rounds, model_tasks)
   if (rlang::is_missing(rounds)) {
     schema_id <- attr(model_tasks, "schema_id")
@@ -16,8 +20,10 @@ check_derived_task_ids <- function(derived_task_ids, rounds, model_tasks,
   pre_v4 <- hubUtils::version_lt("v4.0.0", schema_version = schema_id)
   if (pre_v4) {
     cli::cli_warn(
-      c("!" = "{.arg derived_task_ids} argument is only available for schema version
-                {.val v4.0.0} and later. Ignored."),
+      c(
+        "!" = "{.arg derived_task_ids} argument is only available for schema version
+                {.val v4.0.0} and later. Ignored."
+      ),
       call = call
     )
     return(invisible(FALSE))

--- a/R/check_input.R
+++ b/R/check_input.R
@@ -13,10 +13,14 @@
 #' @return Function used primarily for it's side effects of signalling errors when
 #' input does not conform to schema.
 #' @noRd
-check_input <- function(input, property, parent_schema, # nolint: cyclocomp_linter
-                        parent_property,
-                        scalar = FALSE,
-                        call = rlang::caller_env()) {
+check_input <- function(
+  input,
+  property,
+  parent_schema, # nolint: cyclocomp_linter
+  parent_property,
+  scalar = FALSE,
+  call = rlang::caller_env()
+) {
   property_name <- property # nolint: object_usage_linter
   if (!is.null(parent_property) && parent_property == "value") {
     property_name <- paste0("value_", property)
@@ -27,7 +31,8 @@ check_input <- function(input, property, parent_schema, # nolint: cyclocomp_lint
   if (is.null(input)) {
     property_types <- property_schema[["type"]]
     if (!"null" %in% property_types) {
-      cli::cli_abort(c("x" = "{.arg {property_name}} cannot be NULL."),
+      cli::cli_abort(
+        c("x" = "{.arg {property_name}} cannot be NULL."),
         call = call
       )
     } else {
@@ -35,14 +40,18 @@ check_input <- function(input, property, parent_schema, # nolint: cyclocomp_lint
     }
   }
   if (!is.atomic(input) || is.pairlist(input)) {
-    cli::cli_abort(c("x" = "{.arg {property_name}} must be an atomic vector."),
+    cli::cli_abort(
+      c("x" = "{.arg {property_name}} must be an atomic vector."),
       call = call
     )
   }
 
   if (is.factor(input)) {
-    cli::cli_abort(c("x" = "{.arg {property_name}} cannot be of class
-                     {.cls factor}."),
+    cli::cli_abort(
+      c(
+        "x" = "{.arg {property_name}} cannot be of class
+                     {.cls factor}."
+      ),
       call = call
     )
   }
@@ -137,20 +146,33 @@ check_input <- function(input, property, parent_schema, # nolint: cyclocomp_lint
     }
   }
 
-  if (!is.null(value_formats) && value_formats == "date" && typeof(input) != "character") {
-    cli::cli_abort(c("x" = "{cli::qty(length(input))} {.arg {property_name}}
+  if (
+    !is.null(value_formats) &&
+      value_formats == "date" &&
+      typeof(input) != "character"
+  ) {
+    cli::cli_abort(
+      c(
+        "x" = "{cli::qty(length(input))} {.arg {property_name}}
                          value{?s} must be character string{?s} of date{?s} in valid
                          ISO 8601 format (YYYY-MM-DD). Date object format not accepted.
-                         Consider using {.code as.character()} to convert to character."),
+                         Consider using {.code as.character()} to convert to character."
+      ),
       call = call
     )
   }
 
-  if (!is.null(value_formats) && value_formats == "date" && anyNA(as.Date(input, format = "%Y-%m-%d"))
+  if (
+    !is.null(value_formats) &&
+      value_formats == "date" &&
+      anyNA(as.Date(input, format = "%Y-%m-%d"))
   ) {
-    cli::cli_abort(c("x" = "{cli::qty(length(input))} {.arg {property_name}}
+    cli::cli_abort(
+      c(
+        "x" = "{cli::qty(length(input))} {.arg {property_name}}
                          value{?s} must be character string{?s} of date{?s} in valid
-                         ISO 8601 format (YYYY-MM-DD)."),
+                         ISO 8601 format (YYYY-MM-DD)."
+      ),
       call = call
     )
   }
@@ -257,7 +279,6 @@ check_input <- function(input, property, parent_schema, # nolint: cyclocomp_lint
     }
   }
 
-
   if (any(names(value_schema) == "multipleOf")) {
     is_invalid <- input %% value_schema[["multipleOf"]] != 0L
     if (any(is_invalid)) {
@@ -275,29 +296,32 @@ check_input <- function(input, property, parent_schema, # nolint: cyclocomp_lint
 }
 
 # Used to check properties that contain oneOf schema properties.
-check_oneof_input <- function(input, property = c("required", "optional"), # nolint: cyclocomp_linter
-                              parent_schema,
-                              call = rlang::caller_env()) {
+check_oneof_input <- function(
+  input,
+  property = c("required", "optional"), # nolint: cyclocomp_linter
+  parent_schema,
+  call = rlang::caller_env()
+) {
   property_schema <- parent_schema[[property]]
 
   if (is.null(input)) {
     property_types <- property_schema[["type"]]
     if (!"null" %in% property_types) {
-      cli::cli_abort(c("x" = "{.arg {property}} cannot be NULL."),
-        call = call
-      )
+      cli::cli_abort(c("x" = "{.arg {property}} cannot be NULL."), call = call)
     } else {
       return()
     }
   }
   if (!is.atomic(input) || is.pairlist(input)) {
-    cli::cli_abort(c("x" = "{.arg {property}} must be an atomic vector."),
+    cli::cli_abort(
+      c("x" = "{.arg {property}} must be an atomic vector."),
       call = call
     )
   }
 
   if (is.factor(input)) {
-    cli::cli_abort(c("x" = "{.arg {property}} cannot be of class {.cls factor}."),
+    cli::cli_abort(
+      c("x" = "{.arg {property}} cannot be of class {.cls factor}."),
       call = call
     )
   }
@@ -397,9 +421,15 @@ check_oneof_input <- function(input, property = c("required", "optional"), # nol
 get_schema_output_type <- function(schema, output_type) {
   purrr::pluck(
     schema,
-    "properties", "rounds",
-    "items", "properties", "model_tasks",
-    "items", "properties", "output_type",
-    "properties", output_type
+    "properties",
+    "rounds",
+    "items",
+    "properties",
+    "model_tasks",
+    "items",
+    "properties",
+    "output_type",
+    "properties",
+    output_type
   )
 }

--- a/R/check_properties.R
+++ b/R/check_properties.R
@@ -12,8 +12,12 @@
 #' @return NULL. The functions are called for their side effects.
 #' @noRd
 # Check scalar properties against the schema
-check_properties_scalar <- function(properties, schema, parent_property = NULL,
-                                    call = rlang::caller_env()) {
+check_properties_scalar <- function(
+  properties,
+  schema,
+  parent_property = NULL,
+  call = rlang::caller_env()
+) {
   schema_names <- prop_type_scalar(schema)
   property_names <- intersect(schema_names, names(properties))
 
@@ -33,8 +37,12 @@ check_properties_scalar <- function(properties, schema, parent_property = NULL,
 }
 
 # Check array properties against the schema
-check_properties_array <- function(properties, schema, parent_property = NULL,
-                                   call = rlang::caller_env()) {
+check_properties_array <- function(
+  properties,
+  schema,
+  parent_property = NULL,
+  call = rlang::caller_env()
+) {
   schema_names <- prop_type_array(schema)
   property_names <- intersect(schema_names, names(properties))
 

--- a/R/ci_validate_hub_config.R
+++ b/R/ci_validate_hub_config.R
@@ -102,10 +102,11 @@
 #' head(readLines(diff))
 #' tail(readLines(diff))
 ci_validate_hub_config <- function(
-    hub_path = Sys.getenv("HUB_PATH"),
-    gh_output = Sys.getenv("GITHUB_OUTPUT"),
-    diff = stdout(),
-    ...) {
+  hub_path = Sys.getenv("HUB_PATH"),
+  gh_output = Sys.getenv("GITHUB_OUTPUT"),
+  diff = stdout(),
+  ...
+) {
   v <- validate_hub_config(hub_path = hub_path, ...)
   # check if there were any failures
   invalid <- any(vapply(v, isFALSE, logical(1)))

--- a/R/collect_items.R
+++ b/R/collect_items.R
@@ -1,20 +1,22 @@
-collect_items <- function(...,
-                          item_class = c(
-                            "task_id",
-                            "output_type_item",
-                            "target_metadata_item",
-                            "model_task",
-                            "round"
-                          ),
-                          output_class = c(
-                            "task_ids",
-                            "output_type",
-                            "target_metadata",
-                            "model_tasks",
-                            "rounds"
-                          ),
-                          flatten = TRUE,
-                          call = rlang::caller_env()) {
+collect_items <- function(
+  ...,
+  item_class = c(
+    "task_id",
+    "output_type_item",
+    "target_metadata_item",
+    "model_task",
+    "round"
+  ),
+  output_class = c(
+    "task_ids",
+    "output_type",
+    "target_metadata",
+    "model_tasks",
+    "rounds"
+  ),
+  flatten = TRUE,
+  call = rlang::caller_env()
+) {
   item_class <- rlang::arg_match(item_class)
   output_class <- rlang::arg_match(output_class)
 
@@ -37,15 +39,18 @@ collect_items <- function(...,
     )
   }
   if (item_class == "target_metadata_item") {
-    check_target_metadata_properties_unique(items,
+    check_target_metadata_properties_unique(
+      items,
       property = "target_id",
       call = call
     )
-    check_target_metadata_properties_unique(items,
+    check_target_metadata_properties_unique(
+      items,
       property = "target_name",
       call = call
     )
-    check_target_metadata_properties_unique(items,
+    check_target_metadata_properties_unique(
+      items,
       property = "target_keys",
       call = call
     )
@@ -55,7 +60,8 @@ collect_items <- function(...,
 
   check_items_unique(items, item_class)
 
-  structure(list(items),
+  structure(
+    list(items),
     class = c(output_class, "list"),
     names = output_class,
     n = length(items),
@@ -65,14 +71,12 @@ collect_items <- function(...,
 }
 
 
-
 check_items_unique <- function(items, item_class, call = rlang::caller_env()) {
   is_duplicate <- duplicated(items)
 
   if (any(is_duplicate)) {
     duplicated_items <- items[is_duplicate]
     duplicated_idx <- which(is_duplicate)
-
 
     duplicate_of <- purrr::map2_int(
       duplicated_items,
@@ -81,8 +85,14 @@ check_items_unique <- function(items, item_class, call = rlang::caller_env()) {
     )
 
     duplicate_of_msg <- paste0(
-      "{.cls {item_class}} object ", "{.val {", duplicated_idx, "L}} ",
-      "is a duplicate of object", " {.val {", duplicate_of, "L}}"
+      "{.cls {item_class}} object ",
+      "{.val {",
+      duplicated_idx,
+      "L}} ",
+      "is a duplicate of object",
+      " {.val {",
+      duplicate_of,
+      "L}}"
     ) %>%
       stats::setNames(rep("x", length(duplicate_of)))
 

--- a/R/create_config.R
+++ b/R/create_config.R
@@ -79,9 +79,11 @@
 #'   )
 #' )
 #' create_config(rounds)
-create_config <- function(rounds,
-                          output_type_id_datatype = NULL,
-                          derived_task_ids = NULL) {
+create_config <- function(
+  rounds,
+  output_type_id_datatype = NULL,
+  derived_task_ids = NULL
+) {
   rlang::check_required(rounds)
   check_object_class(rounds, "rounds")
   schema_id <- attr(rounds, "schema_id")
@@ -101,7 +103,8 @@ create_config <- function(rounds,
       rounds = rounds$rounds,
       output_type_id_datatype = output_type_id_datatype,
       derived_task_ids = derived_task_ids
-    ) %>% purrr::compact(), # remove output_type_id_datatype if NULL
+    ) %>%
+      purrr::compact(), # remove output_type_id_datatype if NULL
     class = c("config", "list"),
     type = "tasks",
     schema_id = schema_id,
@@ -110,10 +113,15 @@ create_config <- function(rounds,
 }
 
 check_output_type_id_datatype <- function(schema_id, output_type_id_datatype) {
-  checkmate::assert_choice(output_type_id_datatype,
+  checkmate::assert_choice(
+    output_type_id_datatype,
     c(
-      "auto", "character", "double", "integer",
-      "logical", "Date"
+      "auto",
+      "character",
+      "double",
+      "integer",
+      "logical",
+      "Date"
     ),
     null.ok = TRUE
   )

--- a/R/create_model_task.R
+++ b/R/create_model_task.R
@@ -63,11 +63,8 @@ create_model_task <- function(task_ids, output_type, target_metadata) {
       "output_type",
       "target_metadata"
     ),
-    ~ check_object_class(get(.x), .x,
-      call = call
-    )
+    ~ check_object_class(get(.x), .x, call = call)
   )
-
 
   schema_id <- check_schema_id_attr(
     list(
@@ -103,8 +100,11 @@ create_model_task <- function(task_ids, output_type, target_metadata) {
 }
 
 
-check_target_key_valid <- function(target_metadata, task_ids,
-                                   call = rlang::caller_env()) {
+check_target_key_valid <- function(
+  target_metadata,
+  task_ids,
+  call = rlang::caller_env()
+) {
   target_keys <- purrr::map(
     target_metadata[[1]],
     ~ .x[["target_keys"]]
@@ -135,11 +135,7 @@ check_target_key_valid <- function(target_metadata, task_ids,
   }
   purrr::walk(
     target_keys_names,
-    ~ check_task_id_target_key_values(.x,
-      task_ids,
-      target_keys,
-      call = call
-    )
+    ~ check_task_id_target_key_values(.x, task_ids, target_keys, call = call)
   )
 }
 
@@ -147,15 +143,21 @@ check_target_key_valid <- function(target_metadata, task_ids,
 check_object_class <- function(object, class, call = rlang::caller_env()) {
   if (!inherits(object, class)) {
     cli::cli_abort(
-      c("x" = "{.arg {class}} must inherit from class {.cls {class}} but does not"),
+      c(
+        "x" = "{.arg {class}} must inherit from class {.cls {class}} but does not"
+      ),
       call = call
     )
   }
 }
 
 
-check_task_id_target_key_values <- function(target_key_name, task_ids, # nolint: object_length_linter
-                                            target_keys, call = rlang::caller_env()) {
+check_task_id_target_key_values <- function(
+  target_key_name,
+  task_ids, # nolint: object_length_linter
+  target_keys,
+  call = rlang::caller_env()
+) {
   task_id_values <- unlist(task_ids$task_ids[[target_key_name]]) %>%
     unique() %>%
     sort()
@@ -166,7 +168,6 @@ check_task_id_target_key_values <- function(target_key_name, task_ids, # nolint:
   ) %>%
     unique() %>%
     sort()
-
 
   if (any(task_id_values != target_key_values)) {
     cli::cli_abort(
@@ -183,8 +184,7 @@ check_task_id_target_key_values <- function(target_key_name, task_ids, # nolint:
   }
 }
 
-check_compound_taskids_valid <- function(task_ids,
-                                         output_type) {
+check_compound_taskids_valid <- function(task_ids, output_type) {
   comp_tids <- purrr::pluck(
     output_type,
     "output_type",

--- a/R/create_model_tasks.R
+++ b/R/create_model_tasks.R
@@ -163,7 +163,8 @@
 #'   )
 #' )
 create_model_tasks <- function(...) {
-  collect_items(...,
+  collect_items(
+    ...,
     item_class = "model_task",
     output_class = "model_tasks",
     flatten = FALSE

--- a/R/create_output_type.R
+++ b/R/create_output_type.R
@@ -33,8 +33,10 @@
 #'   )
 #' )
 create_output_type <- function(...) {
-  collect_items(...,
-    item_class = "output_type_item", output_class = "output_type",
+  collect_items(
+    ...,
+    item_class = "output_type_item",
+    output_class = "output_type",
     flatten = TRUE
   )
 }

--- a/R/create_output_type_item.R
+++ b/R/create_output_type_item.R
@@ -47,20 +47,27 @@
 #'   schema_version = "v3.0.1"
 #' )
 #' options(hubAdmin.schema_version = "latest")
-create_output_type_mean <- function(is_required, value_type, value_minimum = NULL,
-                                    value_maximum = NULL,
-                                    schema_version = getOption(
-                                      "hubAdmin.schema_version",
-                                      default = "latest"
-                                    ),
-                                    branch = getOption(
-                                      "hubAdmin.branch",
-                                      default = "main"
-                                    )) {
+create_output_type_mean <- function(
+  is_required,
+  value_type,
+  value_minimum = NULL,
+  value_maximum = NULL,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  )
+) {
   create_output_type_point(
-    output_type = "mean", is_required = is_required,
-    value_type = value_type, value_minimum = value_minimum,
-    value_maximum = value_maximum, schema_version = schema_version,
+    output_type = "mean",
+    is_required = is_required,
+    value_type = value_type,
+    value_minimum = value_minimum,
+    value_maximum = value_maximum,
+    schema_version = schema_version,
     branch = branch
   )
 }
@@ -68,39 +75,48 @@ create_output_type_mean <- function(is_required, value_type, value_minimum = NUL
 #' @export
 #' @describeIn create_output_type_mean Create a list representation of a `median`
 #' output type.
-create_output_type_median <- function(is_required, value_type,
-                                      value_minimum = NULL,
-                                      value_maximum = NULL,
-                                      schema_version = getOption(
-                                        "hubAdmin.schema_version",
-                                        default = "latest"
-                                      ),
-                                      branch = getOption(
-                                        "hubAdmin.branch",
-                                        default = "main"
-                                      )) {
+create_output_type_median <- function(
+  is_required,
+  value_type,
+  value_minimum = NULL,
+  value_maximum = NULL,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  )
+) {
   create_output_type_point(
-    output_type = "median", is_required = is_required,
-    value_type = value_type, value_minimum = value_minimum,
-    value_maximum = value_maximum, schema_version = schema_version,
+    output_type = "median",
+    is_required = is_required,
+    value_type = value_type,
+    value_minimum = value_minimum,
+    value_maximum = value_maximum,
+    schema_version = schema_version,
     branch = branch
   )
 }
 
 
-create_output_type_point <- function(output_type = c("mean", "median"),
-                                     is_required, value_type,
-                                     value_minimum = NULL,
-                                     value_maximum = NULL,
-                                     schema_version = getOption(
-                                       "hubAdmin.schema_version",
-                                       default = "latest"
-                                     ),
-                                     branch = getOption(
-                                       "hubAdmin.branch",
-                                       default = "main"
-                                     ),
-                                     call = rlang::caller_env()) {
+create_output_type_point <- function(
+  output_type = c("mean", "median"),
+  is_required,
+  value_type,
+  value_minimum = NULL,
+  value_maximum = NULL,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  ),
+  call = rlang::caller_env()
+) {
   rlang::check_required(value_type)
   rlang::check_required(is_required)
 
@@ -115,16 +131,20 @@ create_output_type_point <- function(output_type = c("mean", "median"),
 
   # create output_type_id
   if (pre_v4 && is_required) {
-    output_type_id <- list(output_type_id = list(
-      required = NA_character_,
-      optional = NULL
-    ))
+    output_type_id <- list(
+      output_type_id = list(
+        required = NA_character_,
+        optional = NULL
+      )
+    )
   }
   if (pre_v4 && !is_required) {
-    output_type_id <- list(output_type_id = list(
-      required = NULL,
-      optional = NA_character_
-    ))
+    output_type_id <- list(
+      output_type_id = list(
+        required = NULL,
+        optional = NA_character_
+      )
+    )
   }
   if (!pre_v4) {
     output_type_id <- list(
@@ -138,13 +158,16 @@ create_output_type_point <- function(output_type = c("mean", "median"),
   if (hubUtils::version_lt("v2.0.0", schema_version = schema$`$id`)) {
     # Get output type id property according to config schema version
     config_tid <- hubUtils::get_config_tid(
-      config_version = hubUtils::get_schema_version_latest(schema_version, branch)
+      config_version = hubUtils::get_schema_version_latest(
+        schema_version,
+        branch
+      )
     )
     names(output_type_id) <- config_tid
   }
 
-
-  output_type_schema <- get_schema_output_type(schema,
+  output_type_schema <- get_schema_output_type(
+    schema,
     output_type = output_type
   )
 
@@ -162,7 +185,9 @@ create_output_type_point <- function(output_type = c("mean", "median"),
   ) %>%
     purrr::compact()
 
-  check_properties_scalar(value, value_schema,
+  check_properties_scalar(
+    value,
+    value_schema,
     call = call,
     parent_property = "value"
   )
@@ -269,22 +294,31 @@ create_output_type_point <- function(output_type = c("mean", "median"),
 #'   value_type = "double"
 #' )
 #' options(hubAdmin.schema_version = "latest")
-create_output_type_quantile <- function(required, optional,
-                                        is_required, value_type,
-                                        value_minimum = NULL,
-                                        value_maximum = NULL,
-                                        schema_version = getOption(
-                                          "hubAdmin.schema_version",
-                                          default = "latest"
-                                        ),
-                                        branch = getOption(
-                                          "hubAdmin.branch",
-                                          default = "main"
-                                        )) {
+create_output_type_quantile <- function(
+  required,
+  optional,
+  is_required,
+  value_type,
+  value_minimum = NULL,
+  value_maximum = NULL,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  )
+) {
   create_output_type_dist(
-    output_type = "quantile", required = required, optional = optional,
-    is_required = is_required, value_type = value_type, value_minimum = value_minimum,
-    value_maximum = value_maximum, schema_version = schema_version,
+    output_type = "quantile",
+    required = required,
+    optional = optional,
+    is_required = is_required,
+    value_type = value_type,
+    value_minimum = value_minimum,
+    value_maximum = value_maximum,
+    schema_version = schema_version,
     branch = branch
   )
 }
@@ -292,21 +326,29 @@ create_output_type_quantile <- function(required, optional,
 #' @describeIn create_output_type_quantile Create a list representation of a `cdf`
 #' output type.
 #' @export
-create_output_type_cdf <- function(required, optional, is_required,
-                                   value_type,
-                                   schema_version = getOption(
-                                     "hubAdmin.schema_version",
-                                     default = "latest"
-                                   ),
-                                   branch = getOption(
-                                     "hubAdmin.branch",
-                                     default = "main"
-                                   )) {
+create_output_type_cdf <- function(
+  required,
+  optional,
+  is_required,
+  value_type,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  )
+) {
   create_output_type_dist(
-    output_type = "cdf", required = required, optional = optional,
+    output_type = "cdf",
+    required = required,
+    optional = optional,
     is_required = is_required,
-    value_type = value_type, value_minimum = 0L,
-    value_maximum = 1L, schema_version = schema_version,
+    value_type = value_type,
+    value_minimum = 0L,
+    value_maximum = 1L,
+    schema_version = schema_version,
     branch = branch
   )
 }
@@ -314,20 +356,29 @@ create_output_type_cdf <- function(required, optional, is_required,
 #' @describeIn create_output_type_quantile Create a list representation of a `pmf`
 #' output type.
 #' @export
-create_output_type_pmf <- function(required, optional, is_required,
-                                   value_type, schema_version = getOption(
-                                     "hubAdmin.schema_version",
-                                     default = "latest"
-                                   ),
-                                   branch = getOption(
-                                     "hubAdmin.branch",
-                                     default = "main"
-                                   )) {
+create_output_type_pmf <- function(
+  required,
+  optional,
+  is_required,
+  value_type,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  )
+) {
   create_output_type_dist(
-    output_type = "pmf", required = required, optional = optional,
+    output_type = "pmf",
+    required = required,
+    optional = optional,
     is_required = is_required,
-    value_type = value_type, value_minimum = 0L,
-    value_maximum = 1L, schema_version = schema_version,
+    value_type = value_type,
+    value_minimum = 0L,
+    value_maximum = 1L,
+    schema_version = schema_version,
     branch = branch
   )
 }
@@ -347,22 +398,25 @@ create_output_type_pmf <- function(required, optional, is_required,
 #' @describeIn create_output_type_quantile Create a list representation of a `sample`
 #' output type.
 #' @export
-create_output_type_sample <- function(is_required, output_type_id_type,
-                                      max_length = NULL,
-                                      min_samples_per_task,
-                                      max_samples_per_task,
-                                      compound_taskid_set = NULL,
-                                      value_type,
-                                      value_minimum = NULL,
-                                      value_maximum = NULL,
-                                      schema_version = getOption(
-                                        "hubAdmin.schema_version",
-                                        default = "latest"
-                                      ),
-                                      branch = getOption(
-                                        "hubAdmin.branch",
-                                        default = "main"
-                                      )) {
+create_output_type_sample <- function(
+  is_required,
+  output_type_id_type,
+  max_length = NULL,
+  min_samples_per_task,
+  max_samples_per_task,
+  compound_taskid_set = NULL,
+  value_type,
+  value_minimum = NULL,
+  value_maximum = NULL,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  )
+) {
   rlang::check_required(is_required)
   rlang::check_required(output_type_id_type)
   rlang::check_required(min_samples_per_task)
@@ -453,7 +507,9 @@ create_output_type_sample <- function(is_required, output_type_id_type,
     "properties"
   )
 
-  check_properties_scalar(value, value_schema,
+  check_properties_scalar(
+    value,
+    value_schema,
     call = call,
     parent_property = "value"
   )
@@ -469,25 +525,31 @@ create_output_type_sample <- function(is_required, output_type_id_type,
 
 
 create_output_type_dist <- function(
-    output_type = c("quantile", "cdf", "pmf", "sample"),
-    required, optional, is_required,
-    value_type, value_minimum = NULL,
-    value_maximum = NULL, schema_version = getOption(
-      "hubAdmin.schema_version",
-      default = "latest"
-    ),
-    branch = getOption(
-      "hubAdmin.branch",
-      default = "main"
-    ),
-    call = rlang::caller_env()) {
+  output_type = c("quantile", "cdf", "pmf", "sample"),
+  required,
+  optional,
+  is_required,
+  value_type,
+  value_minimum = NULL,
+  value_maximum = NULL,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  ),
+  call = rlang::caller_env()
+) {
   rlang::check_required(value_type)
   rlang::check_required(required)
   output_type <- rlang::arg_match(output_type)
   # Get output type id property according to config schema version
   config_tid <- hubUtils::get_config_tid(
     config_version = hubUtils::get_schema_version_latest(
-      schema_version, branch
+      schema_version,
+      branch
     )
   )
 
@@ -585,7 +647,9 @@ create_output_type_dist <- function(
     "properties"
   )
 
-  check_properties_scalar(value, value_schema,
+  check_properties_scalar(
+    value,
+    value_schema,
     call = call,
     parent_property = "value"
   )

--- a/R/create_rounds.R
+++ b/R/create_rounds.R
@@ -165,7 +165,8 @@
 #'   )
 #' )
 create_rounds <- function(...) {
-  collect_items(...,
+  collect_items(
+    ...,
     item_class = "round",
     output_class = "rounds",
     flatten = FALSE

--- a/R/create_target_metadata.R
+++ b/R/create_target_metadata.R
@@ -32,7 +32,8 @@
 #'   )
 #' )
 create_target_metadata <- function(...) {
-  collect_items(...,
+  collect_items(
+    ...,
     item_class = "target_metadata_item",
     output_class = "target_metadata",
     flatten = FALSE
@@ -40,8 +41,11 @@ create_target_metadata <- function(...) {
 }
 
 
-check_schema_id_attr <- function(items, attribute = c("schema_id", "branch"),
-                                 call = rlang::caller_env()) {
+check_schema_id_attr <- function(
+  items,
+  attribute = c("schema_id", "branch"),
+  call = rlang::caller_env()
+) {
   attribute <- rlang::arg_match(attribute)
   schema_id_attr <- purrr::map_chr(
     items,
@@ -61,7 +65,12 @@ check_schema_id_attr <- function(items, attribute = c("schema_id", "branch"),
       schema_id_attr <- paste(item_names, ":", schema_id_attr)
       obj_ref <- "Argument" # nolint: object_usage_linter
     } else {
-      schema_id_attr <- paste("Item", seq_along(schema_id_attr), ":", schema_id_attr)
+      schema_id_attr <- paste(
+        "Item",
+        seq_along(schema_id_attr),
+        ":",
+        schema_id_attr
+      )
       obj_ref <- "Item"
     }
     names(schema_id_attr) <- rep("*", length(schema_id_attr))
@@ -99,8 +108,11 @@ check_item_classes <- function(items, class, call = rlang::caller_env()) {
   }
 }
 
-check_target_metadata_properties_unique <- function(items, property, # nolint: object_length_linter
-                                                    call = rlang::caller_env()) {
+check_target_metadata_properties_unique <- function(
+  items,
+  property, # nolint: object_length_linter
+  call = rlang::caller_env()
+) {
   item_properties <- purrr::map(
     items,
     ~ .x[[property]]

--- a/R/create_task_id.R
+++ b/R/create_task_id.R
@@ -52,15 +52,19 @@
 #' create_task_id("horizon", required = 1L, optional = 2:4)
 #' create_task_id("location", required = "US", optional = c("01", "02"))
 #' options(hubAdmin.schema_version = "latest")
-create_task_id <- function(name, required, optional,
-                           schema_version = getOption(
-                             "hubAdmin.schema_version",
-                             default = "latest"
-                           ),
-                           branch = getOption(
-                             "hubAdmin.branch",
-                             default = "main"
-                           )) {
+create_task_id <- function(
+  name,
+  required,
+  optional,
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  )
+) {
   checkmate::assert_character(name, len = 1L)
   rlang::check_required(required)
   rlang::check_required(optional)
@@ -117,23 +121,33 @@ create_task_id <- function(name, required, optional,
 get_schema_task_ids <- function(schema) {
   purrr::pluck(
     schema,
-    "properties", "rounds",
-    "items", "properties", "model_tasks",
-    "items", "properties", "task_ids"
+    "properties",
+    "rounds",
+    "items",
+    "properties",
+    "model_tasks",
+    "items",
+    "properties",
+    "task_ids"
   )
 }
 
 #' @importFrom utils askYesNo
-match_element_name <- function(name, element_names,
-                               element = c("task_id", "output_type")) {
+match_element_name <- function(
+  name,
+  element_names,
+  element = c("task_id", "output_type")
+) {
   matched_name <- utils::head(agrep(name, element_names, value = TRUE), 1)
   if (length(matched_name) == 1L && matched_name != name) {
-    ask <- askYesNo(ask_msg(name, matched_name, element),
-      prompts = "Y/N/C"
-    )
+    ask <- askYesNo(ask_msg(name, matched_name, element), prompts = "Y/N/C")
 
-    if (is.na(ask)) stop()
-    if (element != "task_id" && !ask) stop()
+    if (is.na(ask)) {
+      stop()
+    }
+    if (element != "task_id" && !ask) {
+      stop()
+    }
 
     if (ask) {
       name <- matched_name
@@ -171,8 +185,10 @@ ask_msg <- function(name, matched_name, element = c("task_id", "output_type")) {
 
 check_prop_not_all_null <- function(required, optional) {
   if (all(is.null(required), is.null(optional))) {
-    cli::cli_abort(c("x" = "Both arguments {.arg required} and {.arg optional}
-              cannot be NULL."))
+    cli::cli_abort(c(
+      "x" = "Both arguments {.arg required} and {.arg optional}
+              cannot be NULL."
+    ))
   }
 }
 

--- a/R/create_task_ids.R
+++ b/R/create_task_ids.R
@@ -40,8 +40,10 @@
 #'   )
 #' )
 create_task_ids <- function(...) {
-  collect_items(...,
-    item_class = "task_id", output_class = "task_ids",
+  collect_items(
+    ...,
+    item_class = "task_id",
+    output_class = "task_ids",
     flatten = TRUE
   )
 }

--- a/R/download_tasks_schema.R
+++ b/R/download_tasks_schema.R
@@ -16,15 +16,17 @@
 #' download_tasks_schema()
 #' options(hubAdmin.schema_version = "latest")
 download_tasks_schema <- function(
-    schema_version = getOption(
-      "hubAdmin.schema_version",
-      default = "latest"
-    ),
-    branch = getOption(
-      "hubAdmin.branch",
-      default = "main"
-    ),
-    format = c("list", "json")) { # nolint: indentation_linter
+  schema_version = getOption(
+    "hubAdmin.schema_version",
+    default = "latest"
+  ),
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  ),
+  format = c("list", "json")
+) {
+  # nolint: indentation_linter
   format <- rlang::arg_match(format)
 
   # Get the latest version available in our GitHub schema repos
@@ -42,10 +44,9 @@ download_tasks_schema <- function(
 
   schema_json <- hubUtils::get_schema(schema_url)
 
-  switch(format,
-    list = jsonlite::fromJSON(schema_json,
-      simplifyDataFrame = FALSE
-    ),
+  switch(
+    format,
+    list = jsonlite::fromJSON(schema_json, simplifyDataFrame = FALSE),
     json = schema_json
   )
 }

--- a/R/schema_autobox.R
+++ b/R/schema_autobox.R
@@ -88,8 +88,10 @@ schema_autobox <- function(config, box_extra_paths = NULL) {
   checkmate::assert_list(box_extra_paths, null.ok = TRUE)
   if (!inherits(config, "config")) {
     cli::cli_abort(
-      c("x" = "{.arg config} must be an object of class {.cls config}
-             not {.cls {class(config)}}.")
+      c(
+        "x" = "{.arg config} must be an object of class {.cls config}
+             not {.cls {class(config)}}."
+      )
     )
   }
   schema_id <- attr(config, "schema_id")
@@ -201,11 +203,15 @@ expand_items <- function(x, config) {
   item_n <- purrr::pluck(config, !!!at) |>
     length()
 
-  purrr::map(seq_len(item_n), \(.x, item_idx) {
-    x <- as.list(x)
-    x[[item_idx]] <- as.integer(.x)
-    x
-  }, item_idx = item_idx)
+  purrr::map(
+    seq_len(item_n),
+    \(.x, item_idx) {
+      x <- as.list(x)
+      x[[item_idx]] <- as.integer(.x)
+      x
+    },
+    item_idx = item_idx
+  )
 }
 
 

--- a/R/utils-prop_types.R
+++ b/R/utils-prop_types.R
@@ -10,8 +10,7 @@
 prop_type_array <- function(schema, invert = FALSE) {
   predicate <- function(.x) {
     if (is.list(.x)) {
-      "array" %in% .x$type &&
-        .x$items$type != "object"
+      "array" %in% .x$type && .x$items$type != "object"
     } else {
       FALSE
     }
@@ -57,7 +56,8 @@ prop_type_scalar <- function(schema, invert = FALSE) {
   predicate <- function(.x) {
     if (is.list(.x)) {
       any(is.element(
-        .x$type, c("string", "integer", "number", "boolean")
+        .x$type,
+        c("string", "integer", "number", "boolean")
       ))
     } else {
       FALSE

--- a/R/validate-config-utils.R
+++ b/R/validate-config-utils.R
@@ -1,8 +1,10 @@
 # Validate that no task id names match reserved hub variable names
 val_task_id_names <- function(model_task_grp, model_task_i, round_i, schema) {
   reserved_hub_vars <- c(
-    "model_id", "output_type",
-    "output_type_id", "value"
+    "model_id",
+    "output_type",
+    "output_type_id",
+    "value"
   )
   task_id_names <- names(model_task_grp$task_ids)
   check_task_id_names <- task_id_names %in% reserved_hub_vars
@@ -14,7 +16,8 @@ val_task_id_names <- function(model_task_grp, model_task_i, round_i, schema) {
       instancePath = paste0(
         glue::glue(
           get_error_path(schema, "task_ids", "instance")
-        ), "/",
+        ),
+        "/",
         names(invalid_task_id_values)
       ),
       schemaPath = get_error_path(schema, "task_ids", "schema"),
@@ -36,8 +39,12 @@ val_task_id_names <- function(model_task_grp, model_task_i, round_i, schema) {
   NULL
 }
 
-val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
-                                               round_i, schema) {
+val_model_task_grp_target_metadata <- function(
+  model_task_grp,
+  model_task_i,
+  round_i,
+  schema
+) {
   grp_target_keys <- get_grp_target_keys(model_task_grp)
 
   # If all target keys are NULL, exit checks
@@ -48,8 +55,11 @@ val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
   # Check that target key names across items in target metadata array are consistent.
   # If not returns error early as further checks may fail unexpectedly.
   errors_check_1 <- val_target_key_names_const(
-    grp_target_keys, model_task_grp,
-    model_task_i, round_i, schema
+    grp_target_keys,
+    model_task_grp,
+    model_task_i,
+    round_i,
+    schema
   )
 
   if (!is.null(errors_check_1)) {
@@ -68,7 +78,8 @@ val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
   if (any(invalid_target_key_names)) {
     errors_check_2 <- purrr::imap(
       grp_target_keys,
-      ~ val_target_key_names(.x,
+      ~ val_target_key_names(
+        .x,
         target_key_i = .y,
         model_task_grp = model_task_grp,
         model_task_i = model_task_i,
@@ -90,7 +101,9 @@ val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
   # task_id required & optional property arrays.
   errors_check_3 <- purrr::imap(
     grp_target_keys,
-    ~ val_target_key_values(.x, model_task_grp,
+    ~ val_target_key_values(
+      .x,
+      model_task_grp,
       target_key_i = .y,
       model_task_i = model_task_i,
       round_i = round_i,
@@ -102,7 +115,9 @@ val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
   # Check that the unique values in the required & optional property arrays
   #  of each task_id identified as a target key have a matching
   #  value in the corresponding target key of at least one target metadata item.
-  errors_check_4 <- val_target_key_task_id_values(grp_target_keys, model_task_grp,
+  errors_check_4 <- val_target_key_task_id_values(
+    grp_target_keys,
+    model_task_grp,
     model_task_i = model_task_i,
     round_i = round_i,
     schema = schema
@@ -124,20 +139,33 @@ val_model_task_grp_target_metadata <- function(model_task_grp, model_task_i,
   )
 }
 ## GROUP TARGET KEY LEVEL VALIDATIONS ----
-val_target_key_names_const <- function(grp_target_keys, model_task_grp,
-                                       model_task_i, round_i, schema) {
+val_target_key_names_const <- function(
+  grp_target_keys,
+  model_task_grp,
+  model_task_i,
+  round_i,
+  schema
+) {
   target_key_names <- purrr::map(grp_target_keys, ~ names(.x)) %>%
     purrr::map_if(~ !is.null(.x), ~.x, .else = ~"null")
 
   if (length(unique(target_key_names)) > 1) {
     error_row <- data.frame(
-      instancePath = glue::glue(get_error_path(schema, "target_keys", "instance")),
+      instancePath = glue::glue(get_error_path(
+        schema,
+        "target_keys",
+        "instance"
+      )),
       schemaPath = get_error_path(schema, "target_keys", "schema"),
       keyword = "target_keys names",
-      message = glue::glue("target_key names not consistent across target_metadata array items"),
+      message = glue::glue(
+        "target_key names not consistent across target_metadata array items"
+      ),
       schema = "",
-      data = glue::glue("target_key_{seq_along(target_key_names)}: {purrr::map_chr(target_key_names,
-        ~paste(.x, collapse = ','))}") %>%
+      data = glue::glue(
+        "target_key_{seq_along(target_key_names)}: {purrr::map_chr(target_key_names,
+        ~paste(.x, collapse = ','))}"
+      ) %>%
         glue::glue_collapse(sep = ";  ")
     )
     return(error_row)
@@ -145,10 +173,12 @@ val_target_key_names_const <- function(grp_target_keys, model_task_grp,
   NULL
 }
 # Validate that target_ids match corresponding target key values
-val_target_ids_match_target_key_values <- function(grp_target_keys,
-                                                   model_task_i,
-                                                   round_i,
-                                                   schema) {
+val_target_ids_match_target_key_values <- function(
+  grp_target_keys,
+  model_task_i,
+  round_i,
+  schema
+) {
   target_key_values <- purrr::map(
     grp_target_keys,
     ~ .x$target_keys |> unlist()
@@ -161,7 +191,8 @@ val_target_ids_match_target_key_values <- function(grp_target_keys,
   # Check for mismatches between target_id and target_key values. Returns
   # TRUE if there is a mismatch.
   mismatch <- !purrr::map2_lgl(
-    target_ids, target_key_values,
+    target_ids,
+    target_key_values,
     ~ check_target_id(target_id = .x, target_keys = .y)
   )
 
@@ -178,9 +209,7 @@ val_target_ids_match_target_key_values <- function(grp_target_keys,
           model_task_i = model_task_i,
           target_key_i = invalid_target_key_idxs
         ),
-        get_error_path(schema, "target_id", "instance",
-          append_item_n = TRUE
-        )
+        get_error_path(schema, "target_id", "instance", append_item_n = TRUE)
       ),
       schemaPath = get_error_path(schema, "target_id", "schema"),
       keyword = "target_id value",
@@ -197,23 +226,33 @@ val_target_ids_match_target_key_values <- function(grp_target_keys,
   }
 }
 ## TARGET KEY LEVEL VALIDATIONS ----
-val_target_key_names <- function(target_keys, model_task_grp,
-                                 target_key_i, model_task_i,
-                                 round_i, schema) {
+val_target_key_names <- function(
+  target_keys,
+  model_task_grp,
+  target_key_i,
+  model_task_i,
+  round_i,
+  schema
+) {
   check <- find_invalid_target_keys(target_keys, model_task_grp)
 
   if (any(check)) {
     error_row <- data.frame(
       instancePath = paste0(
         glue::glue(get_error_path(schema, "target_keys", "instance")),
-        "/", names(check[check])
+        "/",
+        names(check[check])
       ),
       schemaPath = get_error_path(schema, "target_keys", "schema"),
       keyword = "target_keys names",
-      message = glue::glue("target_key(s) '{names(check[check])}' not properties of modeling task group task IDs"),
+      message = glue::glue(
+        "target_key(s) '{names(check[check])}' not properties of modeling task group task IDs"
+      ),
       schema = "",
-      data = glue::glue("task_id names: {glue::glue_collapse(get_grp_task_ids(model_task_grp), sep = ', ')};
-            target_key names: {glue::glue_collapse(names(target_keys), sep = ', ')}")
+      data = glue::glue(
+        "task_id names: {glue::glue_collapse(get_grp_task_ids(model_task_grp), sep = ', ')};
+            target_key names: {glue::glue_collapse(names(target_keys), sep = ', ')}"
+      )
     )
 
     error_row
@@ -222,9 +261,14 @@ val_target_key_names <- function(target_keys, model_task_grp,
   }
 }
 
-val_target_key_values <- function(target_keys, model_task_grp,
-                                  target_key_i, model_task_i,
-                                  round_i, schema) {
+val_target_key_values <- function(
+  target_keys,
+  model_task_grp,
+  target_key_i,
+  model_task_i,
+  round_i,
+  schema
+) {
   check <- !find_invalid_target_keys(target_keys, model_task_grp)
 
   valid_target_keys <- target_keys[check]
@@ -236,18 +280,18 @@ val_target_key_values <- function(target_keys, model_task_grp,
   ) %>%
     purrr::set_names(names(valid_target_keys))
 
-
   is_invalid_target_key <- purrr::map2_lgl(
-    valid_target_keys, task_id_values,
+    valid_target_keys,
+    task_id_values,
     ~ !.x %in% .y
   )
-
 
   if (any(is_invalid_target_key)) {
     error_row <- data.frame(
       instancePath = paste0(
         glue::glue(get_error_path(schema, "target_keys", "instance")),
-        "/", names(is_invalid_target_key)
+        "/",
+        names(is_invalid_target_key)
       ),
       schemaPath = get_error_path(schema, "target_keys", "schema"),
       keyword = "target_keys values",
@@ -267,10 +311,13 @@ val_target_key_values <- function(target_keys, model_task_grp,
   }
 }
 
-val_target_key_task_id_values <- function(grp_target_keys,
-                                          model_task_grp,
-                                          model_task_i,
-                                          round_i, schema) {
+val_target_key_task_id_values <- function(
+  grp_target_keys,
+  model_task_grp,
+  model_task_i,
+  round_i,
+  schema
+) {
   # Get unique values of target key names
   target_key_names <- purrr::map(grp_target_keys, ~ names(.x)) %>%
     unique() %>%
@@ -280,7 +327,6 @@ val_target_key_task_id_values <- function(grp_target_keys,
   val_target_key_names <- target_key_names[
     target_key_names %in% names(model_task_grp[["task_ids"]])
   ]
-
 
   # Get list of unique task id values across both required & optional arrays
   # for each valid target key.
@@ -310,26 +356,35 @@ val_target_key_task_id_values <- function(grp_target_keys,
     purrr::compact() %>%
     purrr::map_chr(~ paste(.x, collapse = ", "))
 
-
   if (length(invalid_task_id_values) != 0) {
     nms <- names(invalid_task_id_values)
-    tk_unique_vals <- purrr::map_chr( # nolint: object_usage_linter
+    tk_unique_vals <- purrr::map_chr(
+      # nolint: object_usage_linter
       target_key_values[nms],
       ~ paste(.x, collapse = ", ")
     )
-    tid_unique_vals <- purrr::map_chr( # nolint: object_usage_linter
+    tid_unique_vals <- purrr::map_chr(
+      # nolint: object_usage_linter
       task_id_values[nms],
       ~ glue::glue_collapse(.x, sep = ", ")
     )
 
     error_row <- data.frame(
-      instancePath = paste0(glue::glue(get_error_path(schema, "task_ids", "instance")), "/", nms),
+      instancePath = paste0(
+        glue::glue(get_error_path(schema, "task_ids", "instance")),
+        "/",
+        nms
+      ),
       schemaPath = get_error_path(schema, "task_ids", "schema"),
       keyword = "task_id values",
-      message = glue::glue("task_id value(s) '{invalid_task_id_values}' not defined in any corresponding target_key."),
+      message = glue::glue(
+        "task_id value(s) '{invalid_task_id_values}' not defined in any corresponding target_key."
+      ),
       schema = "",
-      data = glue::glue("task_id.{nms} unique values: {tid_unique_vals};
-            target_key.{nms} unique values: {tk_unique_vals}")
+      data = glue::glue(
+        "task_id.{nms} unique values: {tid_unique_vals};
+            target_key.{nms} unique values: {tk_unique_vals}"
+      )
     )
     return(error_row)
   }
@@ -366,17 +421,20 @@ get_round_task_ids <- function(round) {
 }
 
 find_invalid_target_keys <- function(target_keys, model_task_grp) {
-  !names(target_keys) %in% get_grp_task_ids(model_task_grp) %>%
+  !names(target_keys) %in%
+    get_grp_task_ids(model_task_grp) %>%
     stats::setNames(names(target_keys))
 }
 
 # Validate the range (minimum & maximum) of acceptable sample numbers for a
 # given modeling task group in a given round.
 # Returns NULL if not applicable or check passes and error df row if check fails.
-validate_mt_sample_range <- function(model_task_grp,
-                                     model_task_i,
-                                     round_i,
-                                     schema) {
+validate_mt_sample_range <- function(
+  model_task_grp,
+  model_task_i,
+  round_i,
+  schema
+) {
   sample_config <- purrr::pluck(
     model_task_grp,
     "output_type",
@@ -388,7 +446,8 @@ validate_mt_sample_range <- function(model_task_grp,
     return(NULL)
   }
 
-  check <- sample_config$max_samples_per_task < sample_config$min_samples_per_task
+  check <- sample_config$max_samples_per_task <
+    sample_config$min_samples_per_task
 
   if (check) {
     error_row <- data.frame(
@@ -404,7 +463,8 @@ validate_mt_sample_range <- function(model_task_grp,
           schema,
           "sample",
           "schema"
-        ), "output_type_id_params",
+        ),
+        "output_type_id_params",
         sep = "/"
       ),
       keyword = "Sample number range",
@@ -412,8 +472,10 @@ validate_mt_sample_range <- function(model_task_grp,
         "min_samples_per_task must be less or equal to max_samples_per_task."
       ),
       schema = "",
-      data = glue::glue("min_samples_per_task: {sample_config$min_samples_per_task};
-            max_samples_per_task: {sample_config$max_samples_per_task}")
+      data = glue::glue(
+        "min_samples_per_task: {sample_config$min_samples_per_task};
+            max_samples_per_task: {sample_config$max_samples_per_task}"
+      )
     )
     return(error_row)
   }
@@ -423,10 +485,12 @@ validate_mt_sample_range <- function(model_task_grp,
 # Validate that compound_taskid_set values are valid task ids for a
 # given modeling task group in a given round.
 # Returns NULL if not applicable or check passes and error df row if check fails.
-validate_mt_sample_compound_taskids <- function(model_task_grp,
-                                                model_task_i,
-                                                round_i,
-                                                schema) {
+validate_mt_sample_compound_taskids <- function(
+  model_task_grp,
+  model_task_i,
+  round_i,
+  schema
+) {
   sample_config <- purrr::pluck(
     model_task_grp,
     "output_type",
@@ -457,7 +521,9 @@ validate_mt_sample_compound_taskids <- function(model_task_grp,
           schema,
           "sample",
           "schema"
-        ), "output_type_id_params", "compound_taskid_set",
+        ),
+        "output_type_id_params",
+        "compound_taskid_set",
         sep = "/"
       ),
       keyword = "compound_taskid_set values",
@@ -477,22 +543,24 @@ validate_mt_sample_compound_taskids <- function(model_task_grp,
   NULL
 }
 
-validate_mt_property_unique_vals <- function(model_task_grp,
-                                             model_task_i,
-                                             round_i,
-                                             property = c(
-                                               "task_ids",
-                                               "output_type"
-                                             ),
-                                             schema) {
+validate_mt_property_unique_vals <- function(
+  model_task_grp,
+  model_task_i,
+  round_i,
+  property = c(
+    "task_ids",
+    "output_type"
+  ),
+  schema
+) {
   property <- rlang::arg_match(property)
   property_text <- c(
     task_ids = "Task ID",
     output_type = "Output type IDs of output type"
   )[property]
 
-
-  val_properties <- switch(property,
+  val_properties <- switch(
+    property,
     task_ids = model_task_grp[["task_ids"]],
     output_type = model_task_grp[["output_type"]][
       c("quantile", "cdf", "pmf")
@@ -530,27 +598,34 @@ validate_mt_property_unique_vals <- function(model_task_grp,
         instancePath = glue::glue(get_error_path(schema, .y, "instance")),
         schemaPath = get_error_path(schema, .y, "schema"),
         keyword = glue::glue("{property} uniqueItems"),
-        message = glue::glue("must NOT have duplicate items across 'required' and 'optional' properties. {property_text} '{.y}' contains duplicates."),
+        message = glue::glue(
+          "must NOT have duplicate items across 'required' and 'optional' properties. {property_text} '{.y}' contains duplicates."
+        ),
         schema = "",
         data = glue::glue("duplicate values: {paste(.x, collapse = ', ')}")
       )
-    ) %>% purrr::list_rbind()
+    ) %>%
+      purrr::list_rbind()
   }
 }
 
 # Check that modeling task round ids match the expected round ID patterns when
 # round_id_from_variable = TRUE
-validate_mt_round_id_pattern <- function(model_task_grp,
-                                         model_task_i,
-                                         round_i,
-                                         schema,
-                                         round_id_from_variable,
-                                         round_id_var) {
+validate_mt_round_id_pattern <- function(
+  model_task_grp,
+  model_task_i,
+  round_i,
+  schema,
+  round_id_from_variable,
+  round_id_var
+) {
   if (!round_id_from_variable) {
     return(NULL)
   }
   round_id_var_vals <- purrr::pluck(
-    model_task_grp, "task_ids", round_id_var
+    model_task_grp,
+    "task_ids",
+    round_id_var
   )
   invalid_vals <- invalid_round_id_var_patterns(round_id_var_vals)
 
@@ -568,7 +643,8 @@ validate_mt_round_id_pattern <- function(model_task_grp,
         ),
         # using names(invalid_vals_msg) creates a row for each property
         # ("required"/"optional") containing invalid round_id values
-        round_id_var, names(invalid_vals_msg),
+        round_id_var,
+        names(invalid_vals_msg),
         sep = "/"
       ),
       schemaPath = paste(
@@ -576,7 +652,8 @@ validate_mt_round_id_pattern <- function(model_task_grp,
           schema,
           glue::glue("task_ids/{round_id_var}"),
           "schema"
-        ), names(invalid_vals_msg),
+        ),
+        names(invalid_vals_msg),
         sep = "/"
       ),
       keyword = "round_id variable pattern",
@@ -592,8 +669,7 @@ validate_mt_round_id_pattern <- function(model_task_grp,
 }
 ## ROUND LEVEL VALIDATIONS ----
 # Check that round id variables are consistent across modeling tasks
-validate_round_ids_consistent <- function(round, round_i,
-                                          schema) {
+validate_round_ids_consistent <- function(round, round_i, schema) {
   n_mt <- length(round[["model_tasks"]])
 
   if (!round[["round_id_from_variable"]] || n_mt == 1L) {
@@ -613,7 +689,8 @@ validate_round_ids_consistent <- function(round, round_i,
       check <- all.equal(mt[[1]], mt[[.x]])
       if (is.logical(check) && check) NULL else check
     }
-  ) %>% purrr::compact()
+  ) %>%
+    purrr::compact()
 
   if (length(checks) == 0L) {
     return(NULL)
@@ -652,7 +729,8 @@ validate_round_derived_task_ids <- function(round, round_i, schema) {
     invalid_derived_task_ids
   )
   req_derived_task_ids <- derived_task_ids_with_required_vals(
-    round, valid_derived_task_ids,
+    round,
+    valid_derived_task_ids,
     depth = "round"
   )
   names_valid <- length(invalid_derived_task_ids) == 0L
@@ -673,7 +751,8 @@ validate_round_derived_task_ids <- function(round, round_i, schema) {
         )
       ),
       schemaPath = get_error_path(
-        schema, "rounds/items/properties/derived_task_ids",
+        schema,
+        "rounds/items/properties/derived_task_ids",
         "schema"
       ),
       keyword = "round derived task IDs",
@@ -695,7 +774,8 @@ validate_round_derived_task_ids <- function(round, round_i, schema) {
           )
         ),
         schemaPath = get_error_path(
-          schema, "rounds/items/properties/derived_task_ids",
+          schema,
+          "rounds/items/properties/derived_task_ids",
           "schema"
         ),
         keyword = "round derived task IDs",
@@ -726,12 +806,11 @@ validate_round_ids_unique <- function(config_tasks, schema) {
       config_tasks = config_tasks,
       schema = schema
     )
-  ) %>% purrr::list_rbind()
+  ) %>%
+    purrr::list_rbind()
 }
 
-dup_round_id_error_df <- function(dup_round_id,
-                                  config_tasks,
-                                  schema) {
+dup_round_id_error_df <- function(dup_round_id, config_tasks, schema) {
   dup_round_idx <- purrr::imap(
     hubUtils::get_round_ids(config_tasks, flatten = "model_task"),
     ~ {
@@ -745,9 +824,11 @@ dup_round_id_error_df <- function(dup_round_id,
   dup_mt_idx <- purrr::map(
     dup_round_idx,
     ~ hubUtils::get_round_ids(config_tasks, flatten = "task_id")[[.x]] %>%
-      purrr::imap_int(~ {
-        if (dup_round_id %in% .x) .y else NULL
-      }) %>%
+      purrr::imap_int(
+        ~ {
+          if (dup_round_id %in% .x) .y else NULL
+        }
+      ) %>%
       purrr::compact()
   )
 
@@ -760,12 +841,16 @@ dup_round_id_error_df <- function(dup_round_id,
           round_i = .x,
           model_task_i = .y
         ),
-        get_error_path(schema, get_round_id_var(.x, config_tasks), "instance",
+        get_error_path(
+          schema,
+          get_round_id_var(.x, config_tasks),
+          "instance",
           append_item_n = TRUE
         )
       ),
       schemaPath = get_error_path(
-        schema, get_round_id_var(.x, config_tasks),
+        schema,
+        get_round_id_var(.x, config_tasks),
         "schema"
       ),
       keyword = "round_id uniqueItems",
@@ -794,7 +879,8 @@ validate_task_ids_not_all_null <- function(config_tasks, schema) {
 
     error_row <- data.frame(
       instancePath = paste0(
-        "/rounds/*/model_tasks/*/task_ids", "/",
+        "/rounds/*/model_tasks/*/task_ids",
+        "/",
         invalid_task_ids
       ),
       schemaPath = get_error_path(schema, "task_ids", "schema"),
@@ -824,7 +910,8 @@ validate_config_derived_task_ids <- function(config_tasks, schema) {
     invalid_derived_task_ids
   )
   req_derived_task_ids <- derived_task_ids_with_required_vals(
-    config_tasks, valid_derived_task_ids
+    config_tasks,
+    valid_derived_task_ids
   )
   names_valid <- length(invalid_derived_task_ids) == 0L
   no_req_values <- length(req_derived_task_ids) == 0L
@@ -885,21 +972,28 @@ validate_unique_names_recursive <- function(object, object_path = "", schema) {
   if (length(dup_names) == 0L) {
     object_errors <- NULL
   } else {
-    append_item_n <- object_name %in% c("rounds", "target_metadata", "model_tasks")
+    append_item_n <- object_name %in%
+      c("rounds", "target_metadata", "model_tasks")
 
     object_errors <- data.frame(
       instancePath = glue::glue(
-        get_error_path(schema, paste0("/", object_target_path), "instance",
+        get_error_path(
+          schema,
+          paste0("/", object_target_path),
+          "instance",
           append_item_n = append_item_n
         )
       ),
       schemaPath = get_error_path(
-        schema, paste0("/", object_target_path),
+        schema,
+        paste0("/", object_target_path),
         "schema"
       ),
       keyword = glue::glue("{object_name} uniqueNames"),
-      message = glue::glue("{object_name} objects must NOT contain
-                           properties with duplicate names"),
+      message = glue::glue(
+        "{object_name} objects must NOT contain
+                           properties with duplicate names"
+      ),
       schema = "",
       data = glue::glue("duplicate names: {paste(dup_names, collapse = ', ')}")
     )
@@ -920,15 +1014,19 @@ validate_unique_names_recursive <- function(object, object_path = "", schema) {
         schema = schema
       )
     }
-  ) |> purrr::list_rbind()
+  ) |>
+    purrr::list_rbind()
 
   rbind(object_errors, child_errors)
 }
 
 
 ### Utilities ----
-derived_task_ids_with_required_vals <- function(x, derived_task_ids,
-                                                depth = c("config", "round")) {
+derived_task_ids_with_required_vals <- function(
+  x,
+  derived_task_ids,
+  depth = c("config", "round")
+) {
   depth <- rlang::arg_match(depth)
   # If dealing with config depth, extract rounds
   if (depth == "config") {
@@ -972,8 +1070,10 @@ is_null_task_id <- function(task_id_name, config_tasks) {
     config_tasks[["rounds"]],
     ~ .x[["model_tasks"]]
   ) %>%
-    purrr::map(~ .x %>%
-      purrr::map(~ .x[["task_ids"]][[task_id_name]])) %>% # nolint: indentation_linter
+    purrr::map(
+      ~ .x %>%
+        purrr::map(~ .x[["task_ids"]][[task_id_name]])
+    ) %>% # nolint: indentation_linter
     unlist(use.names = FALSE) %>%
     is.null()
 }
@@ -985,7 +1085,9 @@ print.hubval <- function(x, ...) {
   config_dir <- unclass(attr(x, "config_dir"))
   schema_version <- attr(x, "schema_version")
   schema_url <- attr(x, "schema_url")
-  cli::cli_text("{cli::symbol$i} {.href [schema version {schema_version}]({schema_url})}")
+  cli::cli_text(
+    "{cli::symbol$i} {.href [schema version {schema_version}]({schema_url})}"
+  )
   lapply(names(x), function(i) {
     if (x[[i]]) {
       cli::cli_h3("${i}")
@@ -998,7 +1100,6 @@ print.hubval <- function(x, ...) {
   return(invisible(x))
 }
 # nolint end
-
 
 #' @export
 print.conval <- function(x, ...) {
@@ -1077,7 +1178,13 @@ make_config_error <- function(path, msg) {
 parse_object_path <- function(object_path) {
   meta <- vector(mode = "list", length = 5) |>
     purrr::set_names(
-      c("object_name", "object_target_path", "round_i", "model_task_i", "target_key_i")
+      c(
+        "object_name",
+        "object_target_path",
+        "round_i",
+        "model_task_i",
+        "target_key_i"
+      )
     )
 
   path_meta <- strsplit(object_path, "/")[[1]]

--- a/R/validate_model_metadata_schema.R
+++ b/R/validate_model_metadata_schema.R
@@ -25,7 +25,9 @@ validate_model_metadata_schema <- function(hub_path = ".") {
     )
   }
   checkmate::assert_directory_exists(hub_path)
-  config_path <- fs::path(hub_path, "hub-config",
+  config_path <- fs::path(
+    hub_path,
+    "hub-config",
     "model-metadata-schema",
     ext = "json"
   )
@@ -44,7 +46,10 @@ validate_model_metadata_schema <- function(hub_path = ".") {
   )
 
   if (inherits(schema, "try-error")) {
-    validation <- make_config_error(config_path, attr(schema, "condition")$message)
+    validation <- make_config_error(
+      config_path,
+      attr(schema, "condition")$message
+    )
     return(validation)
   }
 
@@ -59,7 +64,8 @@ validate_model_metadata_schema <- function(hub_path = ".") {
 
   if (
     isFALSE(
-      "model_id" %in% properties ||
+      "model_id" %in%
+        properties ||
         all(c("model_abbr", "team_abbr") %in% properties)
     )
   ) {

--- a/R/write_config.R
+++ b/R/write_config.R
@@ -99,13 +99,21 @@
 #'   # Read and print tasks.json again
 #'   cat(readLines(file.path("hub-config", "tasks.json")), sep = "\n")
 #' })
-write_config <- function(config, hub_path = ".", config_path = NULL,
-                         autobox = TRUE, box_extra_paths = NULL,
-                         overwrite = FALSE, silent = FALSE) {
+write_config <- function(
+  config,
+  hub_path = ".",
+  config_path = NULL,
+  autobox = TRUE,
+  box_extra_paths = NULL,
+  overwrite = FALSE,
+  silent = FALSE
+) {
   if (!inherits(config, "config")) {
     cli::cli_abort(
-      c("x" = "{.arg config} must be an object of class {.cls config}
-             not {.cls {class(config)}}.")
+      c(
+        "x" = "{.arg config} must be an object of class {.cls config}
+             not {.cls {class(config)}}."
+      )
     )
   }
 
@@ -118,15 +126,19 @@ write_config <- function(config, hub_path = ".", config_path = NULL,
   parent_dir <- fs::path_dir(config_path)
   if (!fs::dir_exists(parent_dir)) {
     cli::cli_abort(
-      c("x" = "{.arg config_path} parent directory {.field {parent_dir}} does not exist.
-              Can't write to a file in a non-existent directory.")
+      c(
+        "x" = "{.arg config_path} parent directory {.field {parent_dir}} does not exist.
+              Can't write to a file in a non-existent directory."
+      )
     )
   }
 
   if (fs::file_exists(config_path) && isFALSE(overwrite)) {
     cli::cli_abort(
-      c("x" = "File {.arg {config_path}} already exists. Set {.arg overwrite = TRUE}
-              to overwrite the file.")
+      c(
+        "x" = "File {.arg {config_path}} already exists. Set {.arg overwrite = TRUE}
+              to overwrite the file."
+      )
     )
   }
 
@@ -138,7 +150,8 @@ write_config <- function(config, hub_path = ".", config_path = NULL,
     x = config,
     path = config_path,
     auto_unbox = TRUE,
-    na = "string", null = "null",
+    na = "string",
+    null = "null",
     pretty = TRUE
   )
 

--- a/tests/testthat/helper-append_round.R
+++ b/tests/testthat/helper-append_round.R
@@ -1,49 +1,123 @@
 create_new_round <- function(round_id = "2024-09-18") {
   structure(
     list(
-      round_id_from_variable = TRUE, round_id = "nowcast_date",
-      model_tasks = list(list(task_ids = list(
-        nowcast_date = list(
-          required = round_id, optional = NULL
-        ), target_date = list(
-          required = NULL, optional = c(
-            "2024-09-11", "2024-09-04",
-            "2024-08-28", "2024-08-21"
-          )
-        ), location = list(
-          required = NULL,
-          optional = c(
-            "AL", "AK", "AZ", "AR", "CA", "CO", "CT",
-            "DE", "DC", "FL", "GA", "HI", "ID", "IL", "IN", "IA",
-            "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS",
-            "MO", "MT", "NE", "NV", "NH", "NJ", "NM", "NY", "NC",
-            "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN",
-            "TX", "UT", "VT", "VA", "WA", "WV", "WI", "WY", "PR"
+      round_id_from_variable = TRUE,
+      round_id = "nowcast_date",
+      model_tasks = list(list(
+        task_ids = list(
+          nowcast_date = list(
+            required = round_id,
+            optional = NULL
+          ),
+          target_date = list(
+            required = NULL,
+            optional = c(
+              "2024-09-11",
+              "2024-09-04",
+              "2024-08-28",
+              "2024-08-21"
+            )
+          ),
+          location = list(
+            required = NULL,
+            optional = c(
+              "AL",
+              "AK",
+              "AZ",
+              "AR",
+              "CA",
+              "CO",
+              "CT",
+              "DE",
+              "DC",
+              "FL",
+              "GA",
+              "HI",
+              "ID",
+              "IL",
+              "IN",
+              "IA",
+              "KS",
+              "KY",
+              "LA",
+              "ME",
+              "MD",
+              "MA",
+              "MI",
+              "MN",
+              "MS",
+              "MO",
+              "MT",
+              "NE",
+              "NV",
+              "NH",
+              "NJ",
+              "NM",
+              "NY",
+              "NC",
+              "ND",
+              "OH",
+              "OK",
+              "OR",
+              "PA",
+              "RI",
+              "SC",
+              "SD",
+              "TN",
+              "TX",
+              "UT",
+              "VT",
+              "VA",
+              "WA",
+              "WV",
+              "WI",
+              "WY",
+              "PR"
+            )
+          ),
+          variant = list(
+            required = c(
+              "24A",
+              "24B",
+              "24C",
+              "other",
+              "recombinant"
+            ),
+            optional = NULL
           )
         ),
-        variant = list(required = c(
-          "24A", "24B", "24C", "other",
-          "recombinant"
-        ), optional = NULL)
-      ), output_type = list(
-        sample = list(output_type_id_params = list(
-          is_required = FALSE,
-          type = "character", max_length = 15L, min_samples_per_task = 1L,
-          max_samples_per_task = 500L
-        ), value = list(
-          type = "double",
-          minimum = 0L, maximum = 1L
-        ))
-      ), target_metadata = list(
-        list(
-          target_id = "variant prop", target_name = "Weekly nowcasted variant proportions",
-          target_units = "proportion", target_keys = NULL,
-          target_type = "compositional", is_step_ahead = TRUE,
-          time_unit = "week"
+        output_type = list(
+          sample = list(
+            output_type_id_params = list(
+              is_required = FALSE,
+              type = "character",
+              max_length = 15L,
+              min_samples_per_task = 1L,
+              max_samples_per_task = 500L
+            ),
+            value = list(
+              type = "double",
+              minimum = 0L,
+              maximum = 1L
+            )
+          )
+        ),
+        target_metadata = list(
+          list(
+            target_id = "variant prop",
+            target_name = "Weekly nowcasted variant proportions",
+            target_units = "proportion",
+            target_keys = NULL,
+            target_type = "compositional",
+            is_step_ahead = TRUE,
+            time_unit = "week"
+          )
         )
-      ))), submissions_due = list(
+      )),
+      submissions_due = list(
         relative_to = "nowcast_date",
-        start = -7L, end = 1L
+        start = -7L,
+        end = 1L
       )
     ),
     class = c("round", "list"),

--- a/tests/testthat/helper-check_properties.R
+++ b/tests/testthat/helper-check_properties.R
@@ -1,32 +1,58 @@
 create_example_properties <- function() {
   list(
-    round_id_from_variable = TRUE, round_id = "origin_date",
+    round_id_from_variable = TRUE,
+    round_id = "origin_date",
     model_tasks = list(list(
-      task_ids = list(origin_date = list(
-        required = NULL, optional = c(
-          "2023-01-02", "2023-01-09",
-          "2023-01-16"
+      task_ids = list(
+        origin_date = list(
+          required = NULL,
+          optional = c(
+            "2023-01-02",
+            "2023-01-09",
+            "2023-01-16"
+          )
+        ),
+        location = list(
+          required = "US",
+          optional = c(
+            "01",
+            "02",
+            "04",
+            "05",
+            "06"
+          )
+        ),
+        horizon = list(required = 1L, optional = 2:4)
+      ),
+      output_type = list(
+        mean = list(
+          output_type_id = list(
+            required = NA_character_,
+            optional = NULL
+          ),
+          value = list(
+            type = "double",
+            minimum = 0L
+          )
         )
-      ), location = list(required = "US", optional = c(
-        "01",
-        "02", "04", "05", "06"
-      )), horizon = list(required = 1L, optional = 2:4)),
-      output_type = list(mean = list(output_type_id = list(
-        required = NA_character_, optional = NULL
-      ), value = list(
-        type = "double", minimum = 0L
-      ))), target_metadata = list(
+      ),
+      target_metadata = list(
         list(
-          target_id = "inc hosp", target_name = "Weekly incident influenza hospitalizations",
+          target_id = "inc hosp",
+          target_name = "Weekly incident influenza hospitalizations",
           target_units = "rate per 100,000 population",
-          target_keys = NULL, target_type = "discrete",
-          is_step_ahead = TRUE, time_unit = "week"
+          target_keys = NULL,
+          target_type = "discrete",
+          is_step_ahead = TRUE,
+          time_unit = "week"
         )
       )
     )),
     submissions_due = list(
-      relative_to = "origin_date", start = -4L,
+      relative_to = "origin_date",
+      start = -4L,
       end = 2L
-    ), derived_task_ids = "location"
+    ),
+    derived_task_ids = "location"
   )
 }

--- a/tests/testthat/helper-create-version-round.R
+++ b/tests/testthat/helper-create-version-round.R
@@ -1,11 +1,14 @@
-create_derived_task_ids_round <- function(version,
-                                          branch = getOption(
-                                            "hubAdmin.branch",
-                                            default = "main"
-                                          ),
-                                          derived_task_ids = NULL) {
+create_derived_task_ids_round <- function(
+  version,
+  branch = getOption(
+    "hubAdmin.branch",
+    default = "main"
+  ),
+  derived_task_ids = NULL
+) {
   task_ids <- create_task_ids(
-    create_task_id("origin_date",
+    create_task_id(
+      "origin_date",
       required = NULL,
       optional = c(
         "2023-01-02",
@@ -15,13 +18,15 @@ create_derived_task_ids_round <- function(version,
       schema_version = version,
       branch = branch
     ),
-    create_task_id("location",
+    create_task_id(
+      "location",
       required = "US",
       optional = c("01", "02", "04", "05", "06"),
       schema_version = version,
       branch = branch
     ),
-    create_task_id("horizon",
+    create_task_id(
+      "horizon",
       required = 1L,
       optional = 2:4,
       schema_version = version,

--- a/tests/testthat/helper-verify_latest_schema_version.R
+++ b/tests/testthat/helper-verify_latest_schema_version.R
@@ -4,8 +4,10 @@ verify_latest_schema_version <- function(x) {
   latest_version <- hubUtils::get_schema_version_latest()
   is_latest <- schema_id_version == latest_version
   if (!is_latest) {
-    cli::cli_abort("{.var schema_id} version {.val {schema_id_version}} does not
-                       match expected latest version {.val {latest_version}}.")
+    cli::cli_abort(
+      "{.var schema_id} version {.val {schema_id_version}} does not
+                       match expected latest version {.val {latest_version}}."
+    )
   }
 
   attr(x, "schema_id") <- "latest"

--- a/tests/testthat/helper-view-val-tbl.R
+++ b/tests/testthat/helper-view-val-tbl.R
@@ -113,6 +113,8 @@ gt_attr_names <- function() {
     "_substitutions",
     "_styles",
     "_summary",
+    "_summary_cols",
+    "_summary_cols_build",
     "_options",
     "_transforms",
     "_locale",

--- a/tests/testthat/helper-view-val-tbl.R
+++ b/tests/testthat/helper-view-val-tbl.R
@@ -1,6 +1,9 @@
-extract_error_tbl_cols <- function(x, cols = c(
-  "message"
-)) {
+extract_error_tbl_cols <- function(
+  x,
+  cols = c(
+    "message"
+  )
+) {
   attr(x, "errors")[cols] |>
     tibble::as_tibble()
 }
@@ -73,7 +76,6 @@ expect_tab <- function(tab) {
     length() %>%
     expect_equal(0)
 
-
   # Expect that extracted df has the same number of
   # rows as the original dataset
   expect_equal(
@@ -85,8 +87,12 @@ expect_tab <- function(tab) {
   expect_equal(
     colnames(gt:::dt_stub_df_get(data = tab)),
     c(
-      "rownum_i", "row_id", "group_id", "group_label",
-      "indent", "built_group_label"
+      "rownum_i",
+      "row_id",
+      "group_id",
+      "group_label",
+      "indent",
+      "built_group_label"
     )
   )
 }
@@ -94,11 +100,23 @@ expect_tab <- function(tab) {
 
 gt_attr_names <- function() {
   c(
-    "_data", "_boxhead",
-    "_stub_df", "_row_groups",
-    "_heading", "_spanners", "_stubhead",
-    "_footnotes", "_source_notes", "_formats", "_substitutions", "_styles",
-    "_summary", "_options", "_transforms", "_locale", "_has_built"
+    "_data",
+    "_boxhead",
+    "_stub_df",
+    "_row_groups",
+    "_heading",
+    "_spanners",
+    "_stubhead",
+    "_footnotes",
+    "_source_notes",
+    "_formats",
+    "_substitutions",
+    "_styles",
+    "_summary",
+    "_options",
+    "_transforms",
+    "_locale",
+    "_has_built"
   )
 }
 

--- a/tests/testthat/helper-write_config.R
+++ b/tests/testthat/helper-write_config.R
@@ -1,7 +1,8 @@
 # Setup fixtures for creating test objects
 create_test_rounds <- function(
-    branch = "main",
-    version = "v3.0.1") {
+  branch = "main",
+  version = "v3.0.1"
+) {
   create_rounds(
     create_round(
       round_id_from_variable = TRUE,
@@ -9,7 +10,8 @@ create_test_rounds <- function(
       model_tasks = create_model_tasks(
         create_model_task(
           task_ids = create_task_ids(
-            create_task_id("origin_date",
+            create_task_id(
+              "origin_date",
               required = NULL,
               optional = c(
                 "2023-01-02",
@@ -19,13 +21,15 @@ create_test_rounds <- function(
               branch = branch,
               schema_version = version
             ),
-            create_task_id("location",
+            create_task_id(
+              "location",
               required = "US",
               optional = c("01", "02", "04", "05", "06"),
               branch = branch,
               schema_version = version
             ),
-            create_task_id("horizon",
+            create_task_id(
+              "horizon",
               required = 1L,
               optional = 2:4,
               branch = branch,

--- a/tests/testthat/test-append_round.R
+++ b/tests/testthat/test-append_round.R
@@ -10,7 +10,8 @@ test_that("append_round works", {
 
   # Adding two round works
   add_2_rounds <- append_round(
-    config = config, round,
+    config = config,
+    round,
     create_new_round("2024-09-25")
   )
 

--- a/tests/testthat/test-ci_validate_hub_config.R
+++ b/tests/testthat/test-ci_validate_hub_config.R
@@ -9,7 +9,7 @@ test_that("ci_validate_hub creates message of success", {
   tmp <- withr::local_tempdir()
   diff <- withr::local_tempfile()
   fs::dir_copy(system.file("testhubs/simple/", package = "hubUtils"), tmp)
-  out  <- withr::local_tempfile()
+  out <- withr::local_tempfile()
   simp <- fs::path(tmp, "simple")
   # the diff file should not exist
   expect_false(fs::file_exists(diff))
@@ -47,7 +47,6 @@ test_that("ci_validate_hub creates message of success", {
   expect_match(diff2[1], "correct")
   expect_match(tail(diff2, 1), "LATER")
   expect_snapshot(writeLines(diff2))
-
 })
 
 test_that("ci_validate_hub creates message of failure", {
@@ -60,7 +59,7 @@ test_that("ci_validate_hub creates message of failure", {
   }
   tmp <- withr::local_tempdir()
   fs::dir_copy(testthat::test_path("testdata", "error_hub"), tmp)
-  out  <- withr::local_tempfile()
+  out <- withr::local_tempfile()
   diff <- withr::local_tempfile()
   err <- fs::path(tmp, "error_hub")
   # the diff file should not exist
@@ -99,5 +98,4 @@ test_that("ci_validate_hub creates message of failure", {
   diff2 <- readLines(diff)
   expect_match(diff2[1], "Invalid Configuration")
   expect_match(tail(diff2, 1), "LATER")
-
 })

--- a/tests/testthat/test-create_config.R
+++ b/tests/testthat/test-create_config.R
@@ -7,7 +7,8 @@ test_that("create_config functions work correctly", {
       model_tasks = create_model_tasks(
         create_model_task(
           task_ids = create_task_ids(
-            create_task_id("origin_date",
+            create_task_id(
+              "origin_date",
               required = NULL,
               optional = c(
                 "2023-01-02",
@@ -15,14 +16,12 @@ test_that("create_config functions work correctly", {
                 "2023-01-16"
               )
             ),
-            create_task_id("location",
+            create_task_id(
+              "location",
               required = "US",
               optional = c("01", "02", "04", "05", "06")
             ),
-            create_task_id("horizon",
-              required = 1L,
-              optional = 2:4
-            )
+            create_task_id("horizon", required = 1L, optional = 2:4)
           ),
           output_type = create_output_type(
             create_output_type_mean(
@@ -77,10 +76,14 @@ test_that("create_config handles output_type_id_datatype correctly ", {
 
   # Use older schema
   test_rounds_old <- test_rounds
-  attr(test_rounds_old, "schema_id") <- "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json" # nolint line_length_linter
+  attr(
+    test_rounds_old,
+    "schema_id"
+  ) <- "https://raw.githubusercontent.com/hubverse-org/schemas/main/v2.0.0/tasks-schema.json" # nolint line_length_linter
   expect_null(
     suppressMessages(
-      create_config(test_rounds_old,
+      create_config(
+        test_rounds_old,
         output_type_id_datatype = "character"
       )$output_type_id_datatype
     )

--- a/tests/testthat/test-create_model_task.R
+++ b/tests/testthat/test-create_model_task.R
@@ -7,7 +7,8 @@ test_that("create_model_task functions work correctly", {
       model_tasks = create_model_tasks(
         create_model_task(
           task_ids = create_task_ids(
-            create_task_id("origin_date",
+            create_task_id(
+              "origin_date",
               required = NULL,
               optional = c(
                 "2023-01-02",
@@ -15,14 +16,12 @@ test_that("create_model_task functions work correctly", {
                 "2023-01-16"
               )
             ),
-            create_task_id("location",
+            create_task_id(
+              "location",
               required = "US",
               optional = c("01", "02", "04", "05", "06")
             ),
-            create_task_id("horizon",
-              required = 1L,
-              optional = 2:4
-            )
+            create_task_id("horizon", required = 1L, optional = 2:4)
           ),
           output_type = create_output_type(
             create_output_type_mean(
@@ -54,7 +53,8 @@ test_that("create_model_task functions work correctly", {
   expect_snapshot(
     create_model_task(
       task_ids = create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -62,14 +62,12 @@ test_that("create_model_task functions work correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("location",
+        create_task_id(
+          "location",
           required = "US",
           optional = c("01", "02", "04", "05", "06")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       ),
       output_type = create_output_type(
         create_output_type_mean(
@@ -89,13 +87,15 @@ test_that("create_model_task functions work correctly", {
           time_unit = "week"
         )
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 
   expect_snapshot(
     create_model_task(
       task_ids = create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -103,14 +103,12 @@ test_that("create_model_task functions work correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("location",
+        create_task_id(
+          "location",
           required = "US",
           optional = c("01", "02", "04", "05", "06")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       ),
       output_type = create_output_type(
         create_output_type_mean(
@@ -122,7 +120,8 @@ test_that("create_model_task functions work correctly", {
           is_required = FALSE,
           output_type_id_type = "character",
           max_length = 5L,
-          min_samples_per_task = 70L, max_samples_per_task = 100L,
+          min_samples_per_task = 70L,
+          max_samples_per_task = 100L,
           compound_taskid_set = c("horizon", "origin_date"),
           value_type = "double",
           value_minimum = 0L,
@@ -140,13 +139,15 @@ test_that("create_model_task functions work correctly", {
           time_unit = "week"
         )
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 
   expect_snapshot(
     create_model_task(
       task_ids = create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -154,18 +155,17 @@ test_that("create_model_task functions work correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("location",
+        create_task_id(
+          "location",
           required = "US",
           optional = c("01", "02", "04", "05", "06")
         ),
-        create_task_id("target",
+        create_task_id(
+          "target",
           required = NULL,
           optional = c("inc death", "inc hosp")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       ),
       output_type = create_output_type(
         create_output_type_mean(
@@ -179,8 +179,14 @@ test_that("create_model_task functions work correctly", {
         ),
         create_output_type_quantile(
           required = c(
-            0.1, 0.2, 0.3, 0.4, 0.6,
-            0.7, 0.8, 0.9
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.6,
+            0.7,
+            0.8,
+            0.9
           ),
           is_required = TRUE,
           value_type = "double",
@@ -207,7 +213,8 @@ test_that("create_model_task functions work correctly", {
           time_unit = "week"
         )
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 })
 
@@ -219,7 +226,8 @@ test_that("create_output_type_point functions error correctly", {
     ),
     {
       task_ids <- create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -227,14 +235,12 @@ test_that("create_output_type_point functions error correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("target",
+        create_task_id(
+          "target",
           required = NULL,
           optional = c("inc death", "inc hosp")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       )
       output_type <- create_output_type(
         create_output_type_mean(
@@ -300,7 +306,8 @@ test_that("create_output_type_point functions error correctly", {
       )
 
       task_ids <- create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -308,10 +315,7 @@ test_that("create_output_type_point functions error correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       )
 
       attr(task_ids, "schema_id") <- "invalid_schema_id"
@@ -337,7 +341,8 @@ test_that("create_output_type_point functions error correctly", {
       expect_snapshot(
         create_model_task(
           task_ids = create_task_ids(
-            create_task_id("origin_date",
+            create_task_id(
+              "origin_date",
               required = NULL,
               optional = c(
                 "2023-01-02",
@@ -345,14 +350,12 @@ test_that("create_output_type_point functions error correctly", {
                 "2023-01-16"
               )
             ),
-            create_task_id("location",
+            create_task_id(
+              "location",
               required = "US",
               optional = c("01", "02", "04", "05", "06")
             ),
-            create_task_id("horizon",
-              required = 1L,
-              optional = 2:4
-            )
+            create_task_id("horizon", required = 1L, optional = 2:4)
           ),
           output_type = create_output_type(
             create_output_type_mean(
@@ -364,7 +367,8 @@ test_that("create_output_type_point functions error correctly", {
               is_required = FALSE,
               output_type_id_type = "character",
               max_length = 5L,
-              min_samples_per_task = 70L, max_samples_per_task = 100L,
+              min_samples_per_task = 70L,
+              max_samples_per_task = 100L,
               compound_taskid_set = c("horizon", "random_task_id"),
               value_type = "double",
               value_minimum = 0L,

--- a/tests/testthat/test-create_model_tasks.R
+++ b/tests/testthat/test-create_model_tasks.R
@@ -4,7 +4,8 @@ test_that("create_model_tasks functions work correctly", {
     create_model_tasks(
       create_model_task(
         task_ids = create_task_ids(
-          create_task_id("origin_date",
+          create_task_id(
+            "origin_date",
             required = NULL,
             optional = c(
               "2023-01-02",
@@ -12,14 +13,12 @@ test_that("create_model_tasks functions work correctly", {
               "2023-01-16"
             )
           ),
-          create_task_id("location",
+          create_task_id(
+            "location",
             required = "US",
             optional = c("01", "02", "04", "05", "06")
           ),
-          create_task_id("horizon",
-            required = 1L,
-            optional = 2:4
-          )
+          create_task_id("horizon", required = 1L, optional = 2:4)
         ),
         output_type = create_output_type(
           create_output_type_mean(
@@ -40,14 +39,16 @@ test_that("create_model_tasks functions work correctly", {
           )
         )
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 
   expect_snapshot(
     create_model_tasks(
       create_model_task(
         task_ids = create_task_ids(
-          create_task_id("origin_date",
+          create_task_id(
+            "origin_date",
             required = NULL,
             optional = c(
               "2023-01-02",
@@ -55,18 +56,17 @@ test_that("create_model_tasks functions work correctly", {
               "2023-01-16"
             )
           ),
-          create_task_id("location",
+          create_task_id(
+            "location",
             required = "US",
             optional = c("01", "02", "04", "05", "06")
           ),
-          create_task_id("target",
+          create_task_id(
+            "target",
             required = NULL,
             optional = c("inc death", "inc hosp")
           ),
-          create_task_id("horizon",
-            required = 1L,
-            optional = 2:4
-          )
+          create_task_id("horizon", required = 1L, optional = 2:4)
         ),
         output_type = create_output_type(
           create_output_type_mean(
@@ -80,8 +80,14 @@ test_that("create_model_tasks functions work correctly", {
           ),
           create_output_type_quantile(
             required = c(
-              0.1, 0.2, 0.3, 0.4, 0.6,
-              0.7, 0.8, 0.9
+              0.1,
+              0.2,
+              0.3,
+              0.4,
+              0.6,
+              0.7,
+              0.8,
+              0.9
             ),
             is_required = TRUE,
             value_type = "double",
@@ -111,7 +117,8 @@ test_that("create_model_tasks functions work correctly", {
       ),
       create_model_task(
         task_ids = create_task_ids(
-          create_task_id("origin_date",
+          create_task_id(
+            "origin_date",
             required = NULL,
             optional = c(
               "2023-01-02",
@@ -119,18 +126,17 @@ test_that("create_model_tasks functions work correctly", {
               "2023-01-16"
             )
           ),
-          create_task_id("location",
+          create_task_id(
+            "location",
             required = "US",
             optional = c("01", "02", "04", "05", "06")
           ),
-          create_task_id("target",
+          create_task_id(
+            "target",
             required = "flu hosp rt chng",
             optional = NULL
           ),
-          create_task_id("horizon",
-            required = 1L,
-            optional = 2:4
-          )
+          create_task_id("horizon", required = 1L, optional = 2:4)
         ),
         output_type = create_output_type(
           create_output_type_pmf(
@@ -157,10 +163,10 @@ test_that("create_model_tasks functions work correctly", {
           )
         )
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 })
-
 
 
 test_that("create_model_tasks functions error correctly", {
@@ -172,7 +178,8 @@ test_that("create_model_tasks functions error correctly", {
     {
       model_task_1 <- create_model_task(
         task_ids = create_task_ids(
-          create_task_id("origin_date",
+          create_task_id(
+            "origin_date",
             required = NULL,
             optional = c(
               "2023-01-02",
@@ -180,18 +187,17 @@ test_that("create_model_tasks functions error correctly", {
               "2023-01-16"
             )
           ),
-          create_task_id("location",
+          create_task_id(
+            "location",
             required = "US",
             optional = c("01", "02", "04", "05", "06")
           ),
-          create_task_id("target",
+          create_task_id(
+            "target",
             required = NULL,
             optional = c("inc death", "inc hosp")
           ),
-          create_task_id("horizon",
-            required = 1L,
-            optional = 2:4
-          )
+          create_task_id("horizon", required = 1L, optional = 2:4)
         ),
         output_type = create_output_type(
           create_output_type_mean(
@@ -205,8 +211,14 @@ test_that("create_model_tasks functions error correctly", {
           ),
           create_output_type_quantile(
             required = c(
-              0.1, 0.2, 0.3, 0.4, 0.6,
-              0.7, 0.8, 0.9
+              0.1,
+              0.2,
+              0.3,
+              0.4,
+              0.6,
+              0.7,
+              0.8,
+              0.9
             ),
             is_required = TRUE,
             value_type = "double",
@@ -248,7 +260,8 @@ test_that("create_model_tasks functions error correctly", {
           model_task_1,
           create_model_task(
             task_ids = create_task_ids(
-              create_task_id("origin_date",
+              create_task_id(
+                "origin_date",
                 required = NULL,
                 optional = c(
                   "2023-01-02",
@@ -256,18 +269,17 @@ test_that("create_model_tasks functions error correctly", {
                   "2023-01-16"
                 )
               ),
-              create_task_id("location",
+              create_task_id(
+                "location",
                 required = "US",
                 optional = c("01", "02", "04", "05", "06")
               ),
-              create_task_id("target",
+              create_task_id(
+                "target",
                 required = "flu hosp rt chng",
                 optional = NULL
               ),
-              create_task_id("horizon",
-                required = 1L,
-                optional = 2:4
-              )
+              create_task_id("horizon", required = 1L, optional = 2:4)
             ),
             output_type = create_output_type(
               create_output_type_pmf(

--- a/tests/testthat/test-create_output_type.R
+++ b/tests/testthat/test-create_output_type.R
@@ -13,14 +13,21 @@ test_that("create_output_type functions work correctly", {
       ),
       create_output_type_quantile(
         required = c(
-          0.1, 0.2, 0.3, 0.4, 0.6,
-          0.7, 0.8, 0.9
+          0.1,
+          0.2,
+          0.3,
+          0.4,
+          0.6,
+          0.7,
+          0.8,
+          0.9
         ),
         is_required = TRUE,
         value_type = "double",
         value_minimum = 0
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 })
 

--- a/tests/testthat/test-create_output_type_item.R
+++ b/tests/testthat/test-create_output_type_item.R
@@ -67,8 +67,14 @@ test_that("create_output_type_dist functions work correctly", {
     create_output_type_quantile(
       required = c(0.25, 0.5, 0.75),
       optional = c(
-        0.1, 0.2, 0.3, 0.4, 0.6,
-        0.7, 0.8, 0.9
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.6,
+        0.7,
+        0.8,
+        0.9
       ),
       value_type = "double",
       value_minimum = 0,
@@ -99,8 +105,10 @@ test_that("create_output_type_dist functions work correctly", {
     create_output_type_pmf(
       required = NULL,
       optional = c(
-        "low", "moderate",
-        "high", "extreme"
+        "low",
+        "moderate",
+        "high",
+        "extreme"
       ),
       value_type = "double",
       schema_version = "v3.0.1"
@@ -112,8 +120,14 @@ test_that("create_output_type_dist functions work correctly", {
     create_output_type_quantile(
       required = c(0.25, 0.5, 0.75),
       optional = c(
-        0.1, 0.2, 0.3, 0.4, 0.6,
-        0.7, 0.8, 0.9
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.6,
+        0.7,
+        0.8,
+        0.9
       ),
       value_type = "double",
       value_minimum = 0,
@@ -142,8 +156,14 @@ test_that("create_output_type_dist functions error correctly", {
     create_output_type_quantile(
       required = c(0.25, 0.5, 0.6, 0.75),
       optional = c(
-        0.1, 0.2, 0.3, 0.4, 0.6,
-        0.7, 0.8, 0.9
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.6,
+        0.7,
+        0.8,
+        0.9
       ),
       value_type = "double",
       value_minimum = 0
@@ -159,17 +179,20 @@ test_that("create_output_type_sample works", {
     create_output_type_sample(
       is_required = TRUE,
       output_type_id_type = "integer",
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       value_type = "double",
       value_minimum = 0L,
       value_maximum = 1L
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
   expect_snapshot(
     create_output_type_sample(
       is_required = TRUE,
       output_type_id_type = "integer",
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       value_type = "double",
       value_minimum = 0L,
       value_maximum = 1L,
@@ -181,7 +204,8 @@ test_that("create_output_type_sample works", {
       is_required = FALSE,
       output_type_id_type = "character",
       max_length = 5L,
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       compound_taskid_set = c("horizon", "target", "location"),
       value_type = "double",
       value_minimum = 0L,
@@ -198,7 +222,8 @@ test_that("create_output_type_sample errors correctly", {
     create_output_type_sample(
       is_required = TRUE,
       output_type_id_type = "Date",
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       value_type = "double",
       value_minimum = 0L,
       value_maximum = 1L
@@ -210,20 +235,21 @@ test_that("create_output_type_sample errors correctly", {
     create_output_type_sample(
       is_required = 1L,
       output_type_id_type = "Date",
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       value_type = "double",
       value_minimum = 0L,
       value_maximum = 1L
     ),
-    regexp =
-      "Assertion on 'is_required' failed: Must be of type 'logical', not 'integer'"
+    regexp = "Assertion on 'is_required' failed: Must be of type 'logical', not 'integer'"
   )
   # min_samples_per_task vector instead of scalar fails
   expect_snapshot(
     create_output_type_sample(
       is_required = TRUE,
       output_type_id_type = "integer",
-      min_samples_per_task = 10:11, max_samples_per_task = 100L,
+      min_samples_per_task = 10:11,
+      max_samples_per_task = 100L,
       value_type = "character",
       value_minimum = 0L,
       value_maximum = 1L,
@@ -236,7 +262,8 @@ test_that("create_output_type_sample errors correctly", {
     create_output_type_sample(
       is_required = TRUE,
       output_type_id_type = "integer",
-      min_samples_per_task = 110L, max_samples_per_task = 100L,
+      min_samples_per_task = 110L,
+      max_samples_per_task = 100L,
       value_type = "character",
       value_minimum = 0L,
       value_maximum = 1L,
@@ -249,7 +276,8 @@ test_that("create_output_type_sample errors correctly", {
     create_output_type_sample(
       is_required = TRUE,
       output_type_id_type = "integer",
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       value_type = "character",
       value_minimum = 0L,
       value_maximum = 1L,
@@ -264,7 +292,8 @@ test_that("create_output_type_sample errors correctly", {
       is_required = FALSE,
       output_type_id_type = "character",
       max_length = 5L,
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       compound_taskid_set = c(1, 2, 3),
       value_type = "double",
       value_minimum = 0L,
@@ -278,7 +307,8 @@ test_that("create_output_type_sample errors correctly", {
     create_output_type_sample(
       is_required = TRUE,
       output_type_id_type = "integer",
-      min_samples_per_task = 70L, max_samples_per_task = 100L,
+      min_samples_per_task = 70L,
+      max_samples_per_task = 100L,
       value_type = "integer",
       value_minimum = 0L,
       value_maximum = 1L,
@@ -359,15 +389,22 @@ test_that("create_output_type_dist fns support v4 schema", {
       create_output_type_quantile(
         required = c(0.25, 0.5, 0.75),
         optional = c(
-          0.1, 0.2, 0.3, 0.4, 0.6,
-          0.7, 0.8, 0.9
+          0.1,
+          0.2,
+          0.3,
+          0.4,
+          0.6,
+          0.7,
+          0.8,
+          0.9
         ),
         is_required = TRUE,
         value_type = "double",
         value_minimum = 0,
         schema_version = "v4.0.0"
       )$quantile$output_type_id$required
-    ), c(0.25, 0.5, 0.75)
+    ),
+    c(0.25, 0.5, 0.75)
   )
   expect_snapshot(
     create_output_type_cdf(
@@ -390,8 +427,14 @@ test_that("create_output_type_dist fns support v4 schema", {
     create_output_type_quantile(
       required = c(0.25, 0.5, 0.75),
       optional = c(
-        0.1, 0.2, 0.3, 0.4, 0.6,
-        0.7, 0.8, 0.9
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.6,
+        0.7,
+        0.8,
+        0.9
       ),
       is_required = TRUE,
       value_type = "double",
@@ -406,8 +449,14 @@ test_that("create_output_type_dist fns support v4 schema", {
     create_output_type_quantile(
       required = c(0.25, 0.5, 0.75),
       optional = c(
-        0.1, 0.2, 0.3, 0.4, 0.6,
-        0.7, 0.8, 0.9
+        0.1,
+        0.2,
+        0.3,
+        0.4,
+        0.6,
+        0.7,
+        0.8,
+        0.9
       ),
       value_type = "double",
       value_minimum = 0,
@@ -435,7 +484,8 @@ test_that("schema version option works for create_output_type_mean", {
     is_required = TRUE,
     value_type = "double",
     value_minimum = 0L
-  ) |> verify_latest_schema_version()
+  ) |>
+    verify_latest_schema_version()
 
   arg_version <- create_output_type_mean(
     is_required = TRUE,
@@ -472,13 +522,20 @@ test_that("schema version option works for create_output_type_quantile", {
     is_required = FALSE,
     value_type = "double",
     value_minimum = 0
-  ) |> verify_latest_schema_version()
+  ) |>
+    verify_latest_schema_version()
 
   arg_version <- create_output_type_quantile(
     required = c(0.25, 0.5, 0.75),
     optional = c(
-      0.1, 0.2, 0.3, 0.4, 0.6,
-      0.7, 0.8, 0.9
+      0.1,
+      0.2,
+      0.3,
+      0.4,
+      0.6,
+      0.7,
+      0.8,
+      0.9
     ),
     value_type = "double",
     value_minimum = 0,
@@ -495,8 +552,14 @@ test_that("schema version option works for create_output_type_quantile", {
       opt_version <- create_output_type_quantile(
         required = c(0.25, 0.5, 0.75),
         optional = c(
-          0.1, 0.2, 0.3, 0.4, 0.6,
-          0.7, 0.8, 0.9
+          0.1,
+          0.2,
+          0.3,
+          0.4,
+          0.6,
+          0.7,
+          0.8,
+          0.9
         ),
         value_type = "double",
         value_minimum = 0
@@ -521,7 +584,8 @@ test_that("schema version option works for create_output_type_cdf", {
       ),
       is_required = FALSE,
       value_type = "double"
-    ) |> verify_latest_schema_version()
+    ) |>
+    verify_latest_schema_version()
 
   arg_version <-
     create_output_type_cdf(
@@ -565,18 +629,23 @@ test_that("schema version option works for create_output_type_pmf", {
   skip_if_offline()
   version_default <- create_output_type_pmf(
     required = c(
-      "low", "moderate",
-      "high", "extreme"
+      "low",
+      "moderate",
+      "high",
+      "extreme"
     ),
     is_required = FALSE,
     value_type = "double"
-  ) |> verify_latest_schema_version()
+  ) |>
+    verify_latest_schema_version()
 
   arg_version <- create_output_type_pmf(
     required = NULL,
     optional = c(
-      "low", "moderate",
-      "high", "extreme"
+      "low",
+      "moderate",
+      "high",
+      "extreme"
     ),
     value_type = "double",
     schema_version = "v3.0.1",
@@ -592,8 +661,10 @@ test_that("schema version option works for create_output_type_pmf", {
       opt_version <- create_output_type_pmf(
         required = NULL,
         optional = c(
-          "low", "moderate",
-          "high", "extreme"
+          "low",
+          "moderate",
+          "high",
+          "extreme"
         ),
         value_type = "double"
       )
@@ -612,17 +683,20 @@ test_that("schema version option works for create_output_type_sample", {
     is_required = FALSE,
     output_type_id_type = "character",
     max_length = 5L,
-    min_samples_per_task = 70L, max_samples_per_task = 100L,
+    min_samples_per_task = 70L,
+    max_samples_per_task = 100L,
     value_type = "double",
     value_minimum = 0L,
     value_maximum = 1L
-  ) |> verify_latest_schema_version()
+  ) |>
+    verify_latest_schema_version()
 
   arg_version <- create_output_type_sample(
     is_required = FALSE,
     output_type_id_type = "character",
     max_length = 5L,
-    min_samples_per_task = 70L, max_samples_per_task = 100L,
+    min_samples_per_task = 70L,
+    max_samples_per_task = 100L,
     value_type = "double",
     value_minimum = 0L,
     value_maximum = 1L,
@@ -640,7 +714,8 @@ test_that("schema version option works for create_output_type_sample", {
         is_required = FALSE,
         output_type_id_type = "character",
         max_length = 5L,
-        min_samples_per_task = 70L, max_samples_per_task = 100L,
+        min_samples_per_task = 70L,
+        max_samples_per_task = 100L,
         value_type = "double",
         value_minimum = 0L,
         value_maximum = 1L

--- a/tests/testthat/test-create_rounds.R
+++ b/tests/testthat/test-create_rounds.R
@@ -3,7 +3,8 @@ test_that("create_rounds functions work correctly", {
   model_tasks <- create_model_tasks(
     create_model_task(
       task_ids = create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -11,14 +12,12 @@ test_that("create_rounds functions work correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("location",
+        create_task_id(
+          "location",
           required = "US",
           optional = c("01", "02", "04", "05", "06")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       ),
       output_type = create_output_type(
         create_output_type_mean(
@@ -52,52 +51,51 @@ test_that("create_rounds functions work correctly", {
           end = 2L
         )
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
   expect_snapshot(
     create_rounds(
       create_round(
         round_id_from_variable = FALSE,
         round_id = "round_1",
-        model_tasks =
-          create_model_tasks(
-            create_model_task(
-              task_ids = create_task_ids(
-                create_task_id("origin_date",
-                  required = NULL,
-                  optional = c(
-                    "2023-01-09"
-                  )
-                ),
-                create_task_id("location",
-                  required = "US",
-                  optional = c("01", "02", "04", "05", "06")
-                ),
-                create_task_id("horizon",
-                  required = 1L,
-                  optional = 2:4
+        model_tasks = create_model_tasks(
+          create_model_task(
+            task_ids = create_task_ids(
+              create_task_id(
+                "origin_date",
+                required = NULL,
+                optional = c(
+                  "2023-01-09"
                 )
               ),
-              output_type = create_output_type(
-                create_output_type_mean(
-                  is_required = TRUE,
-                  value_type = "double",
-                  value_minimum = 0L
-                )
+              create_task_id(
+                "location",
+                required = "US",
+                optional = c("01", "02", "04", "05", "06")
               ),
-              target_metadata = create_target_metadata(
-                create_target_metadata_item(
-                  target_id = "inc hosp",
-                  target_name = "Weekly incident influenza hospitalizations",
-                  target_units = "rate per 100,000 population",
-                  target_keys = NULL,
-                  target_type = "discrete",
-                  is_step_ahead = TRUE,
-                  time_unit = "week"
-                )
+              create_task_id("horizon", required = 1L, optional = 2:4)
+            ),
+            output_type = create_output_type(
+              create_output_type_mean(
+                is_required = TRUE,
+                value_type = "double",
+                value_minimum = 0L
+              )
+            ),
+            target_metadata = create_target_metadata(
+              create_target_metadata_item(
+                target_id = "inc hosp",
+                target_name = "Weekly incident influenza hospitalizations",
+                target_units = "rate per 100,000 population",
+                target_keys = NULL,
+                target_type = "discrete",
+                is_step_ahead = TRUE,
+                time_unit = "week"
               )
             )
-          ),
+          )
+        ),
         submissions_due = list(
           start = "2023-01-05",
           end = "2023-01-11"
@@ -107,52 +105,51 @@ test_that("create_rounds functions work correctly", {
       create_round(
         round_id_from_variable = FALSE,
         round_id = "round_2",
-        model_tasks =
-          create_model_tasks(
-            create_model_task(
-              task_ids = create_task_ids(
-                create_task_id("origin_date",
-                  required = NULL,
-                  optional = c(
-                    "2023-01-16"
-                  )
-                ),
-                create_task_id("location",
-                  required = "US",
-                  optional = c("01", "02", "04", "05", "06")
-                ),
-                create_task_id("horizon",
-                  required = 1L,
-                  optional = 2:4
+        model_tasks = create_model_tasks(
+          create_model_task(
+            task_ids = create_task_ids(
+              create_task_id(
+                "origin_date",
+                required = NULL,
+                optional = c(
+                  "2023-01-16"
                 )
               ),
-              output_type = create_output_type(
-                create_output_type_mean(
-                  is_required = TRUE,
-                  value_type = "double",
-                  value_minimum = 0L
-                )
+              create_task_id(
+                "location",
+                required = "US",
+                optional = c("01", "02", "04", "05", "06")
               ),
-              target_metadata = create_target_metadata(
-                create_target_metadata_item(
-                  target_id = "inc hosp",
-                  target_name = "Weekly incident influenza hospitalizations",
-                  target_units = "rate per 100,000 population",
-                  target_keys = NULL,
-                  target_type = "discrete",
-                  is_step_ahead = TRUE,
-                  time_unit = "week"
-                )
+              create_task_id("horizon", required = 1L, optional = 2:4)
+            ),
+            output_type = create_output_type(
+              create_output_type_mean(
+                is_required = TRUE,
+                value_type = "double",
+                value_minimum = 0L
+              )
+            ),
+            target_metadata = create_target_metadata(
+              create_target_metadata_item(
+                target_id = "inc hosp",
+                target_name = "Weekly incident influenza hospitalizations",
+                target_units = "rate per 100,000 population",
+                target_keys = NULL,
+                target_type = "discrete",
+                is_step_ahead = TRUE,
+                time_unit = "week"
               )
             )
-          ),
+          )
+        ),
         submissions_due = list(
           start = "2023-01-12",
           end = "2023-01-18"
         ),
         last_data_date = "2023-01-13"
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 })
 
@@ -161,7 +158,8 @@ test_that("create_round errors correctly", {
   model_tasks <- create_model_tasks(
     create_model_task(
       task_ids = create_task_ids(
-        create_task_id("origin_date",
+        create_task_id(
+          "origin_date",
           required = NULL,
           optional = c(
             "2023-01-02",
@@ -169,14 +167,12 @@ test_that("create_round errors correctly", {
             "2023-01-16"
           )
         ),
-        create_task_id("location",
+        create_task_id(
+          "location",
           required = "US",
           optional = c("01", "02", "04", "05", "06")
         ),
-        create_task_id("horizon",
-          required = 1L,
-          optional = 2:4
-        )
+        create_task_id("horizon", required = 1L, optional = 2:4)
       ),
       output_type = create_output_type(
         create_output_type_mean(

--- a/tests/testthat/test-create_target_metadata.R
+++ b/tests/testthat/test-create_target_metadata.R
@@ -20,7 +20,8 @@ test_that("create_target_metadata functions work correctly", {
         is_step_ahead = TRUE,
         time_unit = "week"
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 })
 

--- a/tests/testthat/test-create_task_id.R
+++ b/tests/testthat/test-create_task_id.R
@@ -1,47 +1,49 @@
 test_that("create_task_id works correctly", {
   skip_if_offline()
   expect_snapshot(
-    create_task_id("horizon",
-      required = 1L,
-      optional = 2:4
-    ) |> verify_latest_schema_version()
+    create_task_id("horizon", required = 1L, optional = 2:4) |>
+      verify_latest_schema_version()
   )
 
   expect_snapshot(
-    create_task_id("origin_date",
+    create_task_id(
+      "origin_date",
       required = NULL,
       optional = c(
         "2023-01-02",
         "2023-01-09",
         "2023-01-16"
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 
   expect_snapshot(
-    create_task_id("scenario_id",
+    create_task_id(
+      "scenario_id",
       required = NULL,
       optional = c(
         "A-2021-03-28",
         "B-2021-03-28"
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
 
   expect_snapshot(
-    create_task_id("scenario_id",
+    create_task_id(
+      "scenario_id",
       required = NULL,
       optional = c(
         1L,
         2L
       )
-    ) |> verify_latest_schema_version()
+    ) |>
+      verify_latest_schema_version()
   )
   expect_snapshot(
-    create_task_id("horizon",
-      required = NULL,
-      optional = NULL
-    ) |> verify_latest_schema_version()
+    create_task_id("horizon", required = NULL, optional = NULL) |>
+      verify_latest_schema_version()
   )
 })
 
@@ -49,14 +51,12 @@ test_that("create_task_id works correctly", {
 test_that("create_task_id errors correctly", {
   skip_if_offline()
   expect_snapshot(
-    create_task_id("origin_date",
-      required = NULL,
-      optional = c("01/20/2023")
-    ),
+    create_task_id("origin_date", required = NULL, optional = c("01/20/2023")),
     error = TRUE
   )
   expect_snapshot(
-    create_task_id("scenario_id",
+    create_task_id(
+      "scenario_id",
       required = NULL,
       optional = c(
         1L,
@@ -66,10 +66,7 @@ test_that("create_task_id errors correctly", {
     error = TRUE
   )
   expect_snapshot(
-    create_task_id("horizon",
-      required = c(TRUE, FALSE),
-      optional = NULL
-    ),
+    create_task_id("horizon", required = c(TRUE, FALSE), optional = NULL),
     error = TRUE
   )
 })
@@ -82,7 +79,8 @@ test_that("create_task_id name matching works correctly", {
   expect_equal(
     names(
       suppressMessages(
-        create_task_id("scenario_ids",
+        create_task_id(
+          "scenario_ids",
           required = NULL,
           optional = c(
             "A-2021-03-28",
@@ -109,12 +107,11 @@ test_that("create_task_id name matching works correctly", {
 
 test_that("schema version option works for create_task_id", {
   skip_if_offline()
-  version_default <- create_task_id("horizon",
-    required = 1L,
-    optional = 2:4
-  ) |> verify_latest_schema_version()
+  version_default <- create_task_id("horizon", required = 1L, optional = 2:4) |>
+    verify_latest_schema_version()
 
-  arg_version <- create_task_id("horizon",
+  arg_version <- create_task_id(
+    "horizon",
     required = 1L,
     optional = 2:4,
     schema_version = "v3.0.1",
@@ -127,10 +124,7 @@ test_that("schema version option works for create_task_id", {
       hubAdmin.branch = "main"
     ),
     {
-      opt_version <- create_task_id("horizon",
-        required = 1L,
-        optional = 2:4
-      )
+      opt_version <- create_task_id("horizon", required = 1L, optional = 2:4)
     }
   )
   expect_equal(arg_version, opt_version)

--- a/tests/testthat/test-create_task_ids.R
+++ b/tests/testthat/test-create_task_ids.R
@@ -2,7 +2,8 @@ test_that("create_task_ids functions work correctly", {
   skip_if_offline()
   expect_snapshot(
     create_task_ids(
-      create_task_id("origin_date",
+      create_task_id(
+        "origin_date",
         required = NULL,
         optional = c(
           "2023-01-02",
@@ -10,26 +11,23 @@ test_that("create_task_ids functions work correctly", {
           "2023-01-16"
         )
       ),
-      create_task_id("scenario_id",
+      create_task_id(
+        "scenario_id",
         required = NULL,
         optional = c(
           "A-2021-03-28",
           "B-2021-03-28"
         )
       ),
-      create_task_id("location",
+      create_task_id(
+        "location",
         required = "US",
         optional = c("01", "02", "04", "05", "06")
       ),
-      create_task_id("target",
-        required = "inc hosp",
-        optional = NULL
-      ),
-      create_task_id("horizon",
-        required = 1L,
-        optional = 2:4
-      )
-    ) |> verify_latest_schema_version()
+      create_task_id("target", required = "inc hosp", optional = NULL),
+      create_task_id("horizon", required = 1L, optional = 2:4)
+    ) |>
+      verify_latest_schema_version()
   )
 })
 
@@ -38,7 +36,8 @@ test_that("create_task_ids functions error correctly", {
   skip_if_offline()
   expect_snapshot(
     create_task_ids(
-      create_task_id("origin_date",
+      create_task_id(
+        "origin_date",
         required = NULL,
         optional = c(
           "2023-01-02",
@@ -46,7 +45,8 @@ test_that("create_task_ids functions error correctly", {
           "2023-01-16"
         )
       ),
-      create_task_id("origin_date",
+      create_task_id(
+        "origin_date",
         required = NULL,
         optional = c(
           "2023-01-02",
@@ -60,7 +60,8 @@ test_that("create_task_ids functions error correctly", {
 
   expect_snapshot(
     create_task_ids(
-      create_task_id("origin_date",
+      create_task_id(
+        "origin_date",
         required = NULL,
         optional = c(
           "2023-01-02",
@@ -80,7 +81,8 @@ test_that("create_task_ids functions error correctly", {
       hubAdmin.branch = "main"
     ),
     {
-      item_1 <- create_task_id("origin_date",
+      item_1 <- create_task_id(
+        "origin_date",
         required = NULL,
         optional = c(
           "2023-01-02",
@@ -92,7 +94,8 @@ test_that("create_task_ids functions error correctly", {
       expect_snapshot(
         create_task_ids(
           item_1,
-          create_task_id("scenario_id",
+          create_task_id(
+            "scenario_id",
             required = NULL,
             optional = c(
               "A-2021-03-28",

--- a/tests/testthat/test-download_tasks_schema.R
+++ b/tests/testthat/test-download_tasks_schema.R
@@ -8,8 +8,14 @@ test_that("download_tasks_schema defaults work", {
   expect_equal(
     names(latest_schema),
     c(
-      "$schema", "$id", "title", "description", "type", "properties",
-      "required", "additionalProperties"
+      "$schema",
+      "$id",
+      "title",
+      "description",
+      "type",
+      "properties",
+      "required",
+      "additionalProperties"
     )
   )
 })

--- a/tests/testthat/test-schema_autobox.R
+++ b/tests/testthat/test-schema_autobox.R
@@ -14,7 +14,8 @@ test_that("schema autobox boxes length 1L vectors correctly", {
             model_tasks = create_model_tasks(
               create_model_task(
                 task_ids = create_task_ids(
-                  create_task_id("origin_date",
+                  create_task_id(
+                    "origin_date",
                     required = NULL,
                     optional = c(
                       "2023-01-02",
@@ -22,14 +23,12 @@ test_that("schema autobox boxes length 1L vectors correctly", {
                       "2023-01-16"
                     )
                   ),
-                  create_task_id("location",
+                  create_task_id(
+                    "location",
                     required = "US",
                     optional = c("01", "02", "04", "05", "06")
                   ),
-                  create_task_id("horizon",
-                    required = 1L,
-                    optional = 2:4
-                  )
+                  create_task_id("horizon", required = 1L, optional = 2:4)
                 ),
                 output_type = create_output_type(
                   create_output_type_mean(
@@ -67,21 +66,29 @@ test_that("schema autobox boxes length 1L vectors correctly", {
       expect_snapshot(
         schema_autobox(config) |>
           jsonlite::toJSON(
-            auto_unbox = TRUE, na = "string",
-            null = "null", pretty = TRUE
+            auto_unbox = TRUE,
+            na = "string",
+            null = "null",
+            pretty = TRUE
           )
       )
       expect_snapshot(
         waldo::compare(
           config$rounds[[1]]$model_tasks[[1]]$task_ids$location$required |>
             jsonlite::toJSON(
-              auto_unbox = TRUE, na = "string",
-              null = "null", pretty = TRUE
+              auto_unbox = TRUE,
+              na = "string",
+              null = "null",
+              pretty = TRUE
             ),
-          schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$task_ids$location$required |>
+          schema_autobox(config)$rounds[[1]]$model_tasks[[
+            1
+          ]]$task_ids$location$required |>
             jsonlite::toJSON(
-              auto_unbox = TRUE, na = "string",
-              null = "null", pretty = TRUE
+              auto_unbox = TRUE,
+              na = "string",
+              null = "null",
+              pretty = TRUE
             )
         )
       )
@@ -90,28 +97,42 @@ test_that("schema autobox boxes length 1L vectors correctly", {
         waldo::compare(
           config$rounds[[1]]$model_tasks[[1]]$task_ids$horizon$required |>
             jsonlite::toJSON(
-              auto_unbox = TRUE, na = "string",
-              null = "null", pretty = TRUE
+              auto_unbox = TRUE,
+              na = "string",
+              null = "null",
+              pretty = TRUE
             ),
-          schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$task_ids$horizon$required |>
+          schema_autobox(config)$rounds[[1]]$model_tasks[[
+            1
+          ]]$task_ids$horizon$required |>
             jsonlite::toJSON(
-              auto_unbox = TRUE, na = "string",
-              null = "null", pretty = TRUE
+              auto_unbox = TRUE,
+              na = "string",
+              null = "null",
+              pretty = TRUE
             )
         )
       )
 
       expect_snapshot(
         waldo::compare(
-          config$rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id$required |>
+          config$rounds[[1]]$model_tasks[[
+            1
+          ]]$output_type$mean$output_type_id$required |>
             jsonlite::toJSON(
-              auto_unbox = TRUE, na = "string",
-              null = "null", pretty = TRUE
+              auto_unbox = TRUE,
+              na = "string",
+              null = "null",
+              pretty = TRUE
             ),
-          schema_autobox(config)$rounds[[1]]$model_tasks[[1]]$output_type$mean$output_type_id$required |>
+          schema_autobox(config)$rounds[[1]]$model_tasks[[
+            1
+          ]]$output_type$mean$output_type_id$required |>
             jsonlite::toJSON(
-              auto_unbox = TRUE, na = "string",
-              null = "null", pretty = TRUE
+              auto_unbox = TRUE,
+              na = "string",
+              null = "null",
+              pretty = TRUE
             )
         )
       )
@@ -130,8 +151,10 @@ test_that("schema autobox boxes length 1L vectors correctly", {
       expect_snapshot(
         schema_autobox(more_rounds_config) |>
           jsonlite::toJSON(
-            auto_unbox = TRUE, na = "string",
-            null = "null", pretty = TRUE
+            auto_unbox = TRUE,
+            na = "string",
+            null = "null",
+            pretty = TRUE
           )
       )
     }
@@ -170,7 +193,9 @@ test_that("schema autobox works on additionalProperties", {
 
   # Check that the config file is processed correctly
   expect_snapshot(
-    schema_autobox(nowcast_config)$rounds[[1]]$model_tasks[[1]]$task_ids$nowcast_date
+    schema_autobox(nowcast_config)$rounds[[1]]$model_tasks[[
+      1
+    ]]$task_ids$nowcast_date
   )
   expect_snapshot(
     schema_autobox(nowcast_config)$rounds[[1]]$model_tasks[[1]]$task_ids$variant
@@ -180,23 +205,33 @@ test_that("schema autobox works on additionalProperties", {
   expect_snapshot(
     schema_autobox(nowcast_config) |>
       jsonlite::toJSON(
-        auto_unbox = TRUE, na = "string",
-        null = "null", pretty = TRUE
+        auto_unbox = TRUE,
+        na = "string",
+        null = "null",
+        pretty = TRUE
       )
   )
 
   # Specifically compare the nowcast_date required property
   expect_snapshot(
     waldo::compare(
-      nowcast_config$rounds[[1]]$model_tasks[[1]]$task_ids$nowcast_date$required |>
+      nowcast_config$rounds[[1]]$model_tasks[[
+        1
+      ]]$task_ids$nowcast_date$required |>
         jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
+          auto_unbox = TRUE,
+          na = "string",
+          null = "null",
+          pretty = TRUE
         ),
-      schema_autobox(nowcast_config)$rounds[[1]]$model_tasks[[1]]$task_ids$nowcast_date$required |>
+      schema_autobox(nowcast_config)$rounds[[1]]$model_tasks[[
+        1
+      ]]$task_ids$nowcast_date$required |>
         jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
+          auto_unbox = TRUE,
+          na = "string",
+          null = "null",
+          pretty = TRUE
         )
     )
   )
@@ -214,16 +249,20 @@ test_that("schema autobox box_extra_paths works", {
     waldo::compare(
       nowcast_config$rounds[[1]]$extra_array_property |>
         jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
+          auto_unbox = TRUE,
+          na = "string",
+          null = "null",
+          pretty = TRUE
         ),
       schema_autobox(
         nowcast_config,
         list(c("rounds", "items", "extra_array_property"))
       )$rounds[[1]]$extra_array_property |>
         jsonlite::toJSON(
-          auto_unbox = TRUE, na = "string",
-          null = "null", pretty = TRUE
+          auto_unbox = TRUE,
+          na = "string",
+          null = "null",
+          pretty = TRUE
         )
     )
   )

--- a/tests/testthat/test-utils-prop_types.R
+++ b/tests/testthat/test-utils-prop_types.R
@@ -7,8 +7,14 @@ test_that("prop_type_scalar works at top level", {
   expect_equal(
     prop_type_scalar(schema, invert = TRUE),
     c(
-      "$schema", "$id", "title", "description", "type", "properties",
-      "required", "additionalProperties"
+      "$schema",
+      "$id",
+      "title",
+      "description",
+      "type",
+      "properties",
+      "required",
+      "additionalProperties"
     )
   )
 
@@ -59,8 +65,14 @@ test_that("prop_type_array works at top level", {
   expect_equal(
     prop_type_array(schema, invert = TRUE),
     c(
-      "$schema", "$id", "title", "description", "type", "properties",
-      "required", "additionalProperties"
+      "$schema",
+      "$id",
+      "title",
+      "description",
+      "type",
+      "properties",
+      "required",
+      "additionalProperties"
     )
   )
 
@@ -90,8 +102,12 @@ test_that("prop_type_array works at round level", {
   expect_equal(
     prop_type_array(round_schema, invert = TRUE),
     c(
-      "round_id_from_variable", "round_id", "round_name", "model_tasks",
-      "submissions_due", "last_data_date"
+      "round_id_from_variable",
+      "round_id",
+      "round_name",
+      "model_tasks",
+      "submissions_due",
+      "last_data_date"
     )
   )
   # Check that default + inverse calls return all schema property names
@@ -111,8 +127,14 @@ test_that("prop_type_object works at top level", {
   expect_equal(
     prop_type_object(schema, invert = TRUE),
     c(
-      "$schema", "$id", "title", "description", "type", "properties",
-      "required", "additionalProperties"
+      "$schema",
+      "$id",
+      "title",
+      "description",
+      "type",
+      "properties",
+      "required",
+      "additionalProperties"
     )
   )
 
@@ -142,8 +164,12 @@ test_that("prop_type_object works at round level", {
   expect_equal(
     prop_type_object(round_schema, invert = TRUE),
     c(
-      "round_id_from_variable", "round_id", "round_name", "model_tasks",
-      "last_data_date", "file_format"
+      "round_id_from_variable",
+      "round_id",
+      "round_name",
+      "model_tasks",
+      "last_data_date",
+      "file_format"
     )
   )
   # Check that default + inverse calls return all schema property names
@@ -163,8 +189,14 @@ test_that("prop_type_object_array works at top level", {
   expect_equal(
     prop_type_object_array(schema, invert = TRUE),
     c(
-      "$schema", "$id", "title", "description", "type", "properties",
-      "required", "additionalProperties"
+      "$schema",
+      "$id",
+      "title",
+      "description",
+      "type",
+      "properties",
+      "required",
+      "additionalProperties"
     )
   )
 
@@ -197,8 +229,12 @@ test_that("prop_type_object_array works at round level", {
   expect_equal(
     prop_type_object_array(round_schema, invert = TRUE),
     c(
-      "round_id_from_variable", "round_id", "round_name",
-      "submissions_due", "last_data_date", "file_format"
+      "round_id_from_variable",
+      "round_id",
+      "round_name",
+      "submissions_due",
+      "last_data_date",
+      "file_format"
     )
   )
   # Check that default + inverse calls return all schema property names

--- a/tests/testthat/test-validate-config-utils.R
+++ b/tests/testthat/test-validate-config-utils.R
@@ -2,7 +2,9 @@ test_that("val_target_ids_match_target_key_values works", {
   # Ensure validation returns mismatches between target IDs and target keys
   # correctly when multiple target keys are present.
   grp_target_keys <- jsonlite::read_json(
-    testthat::test_path("testdata/target-metadata-target-id-target-key-mismatch.json"),
+    testthat::test_path(
+      "testdata/target-metadata-target-id-target-key-mismatch.json"
+    ),
     simplifyVector = TRUE,
     simplifyDataFrame = FALSE
   )$target_metadata
@@ -12,7 +14,10 @@ test_that("val_target_ids_match_target_key_values works", {
   schema <- hubUtils::get_schema(hubUtils::get_schema_url(version = "v5.0.0"))
 
   check <- val_target_ids_match_target_key_values(
-    grp_target_keys, model_task_i, round_i, schema
+    grp_target_keys,
+    model_task_i,
+    round_i,
+    schema
   )
   expect_equal(
     check,
@@ -58,7 +63,10 @@ test_that("val_target_ids_match_target_key_values works", {
   # correctly when a single target keys are present.
   grp_target_keys <- grp_target_keys[2]
   check <- val_target_ids_match_target_key_values(
-    grp_target_keys, model_task_i, round_i, schema
+    grp_target_keys,
+    model_task_i,
+    round_i,
+    schema
   )
   expect_equal(
     check,
@@ -68,8 +76,7 @@ test_that("val_target_ids_match_target_key_values works", {
           "/rounds/0/model_tasks/0/target_metadata/0/target_id",
           class = c("glue", "character")
         ),
-        schemaPath =
-          "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata/items/properties/target_id", # nolint: line_length_linter
+        schemaPath = "#/properties/rounds/items/properties/model_tasks/items/properties/target_metadata/items/properties/target_id", # nolint: line_length_linter
         keyword = "target_id value",
         message = "target_id value does not match corresponding target key value",
         schema = "",
@@ -78,14 +85,18 @@ test_that("val_target_ids_match_target_key_values works", {
           class = c("glue", "character")
         )
       ),
-      class = "data.frame", row.names = c(NA, -1L)
+      class = "data.frame",
+      row.names = c(NA, -1L)
     )
   )
 
   # Ensure validation returns NULL when target keys are NULL
   grp_target_keys[[1]]$target_keys <- NULL
   check <- val_target_ids_match_target_key_values(
-    grp_target_keys, model_task_i, round_i, schema
+    grp_target_keys,
+    model_task_i,
+    round_i,
+    schema
   )
   expect_null(check)
 
@@ -97,7 +108,10 @@ test_that("val_target_ids_match_target_key_values works", {
     target_outcome = "hospitalisation"
   )
   check <- val_target_ids_match_target_key_values(
-    grp_target_keys, model_task_i, round_i, schema
+    grp_target_keys,
+    model_task_i,
+    round_i,
+    schema
   )
   expect_null(check)
 })

--- a/tests/testthat/test-validate-inst-hubs.R
+++ b/tests/testthat/test-validate-inst-hubs.R
@@ -5,9 +5,7 @@ test_that("simple example hub configured correctly", {
       unlist(
         suppressMessages(
           validate_hub_config(
-            hub_path = system.file("testhubs/simple",
-              package = "hubUtils"
-            )
+            hub_path = system.file("testhubs/simple", package = "hubUtils")
           )
         )
       )
@@ -22,9 +20,7 @@ test_that("flusight example hub configured correctly", {
       unlist(
         suppressMessages(
           validate_hub_config(
-            hub_path = system.file("testhubs/flusight",
-              package = "hubUtils"
-            )
+            hub_path = system.file("testhubs/flusight", package = "hubUtils")
           )
         )
       )

--- a/tests/testthat/test-validate_model_metadata_schema.R
+++ b/tests/testthat/test-validate_model_metadata_schema.R
@@ -2,7 +2,8 @@ test_that("Missing files returns an invalid config with an immediate message", {
   withr::local_options(list(width = 120))
   tmp <- withr::local_tempdir()
   suppressMessages({
-    expect_message(out <- validate_model_metadata_schema(hub_path = tmp),
+    expect_message(
+      out <- validate_model_metadata_schema(hub_path = tmp),
       "File does not exist"
     )
   })
@@ -26,7 +27,8 @@ test_that("validate_model_metadata_schema works", {
   out_error <- suppressWarnings(
     validate_model_metadata_schema(
       hub_path = testthat::test_path(
-        "testdata", "error_hub"
+        "testdata",
+        "error_hub"
       )
     )
   )
@@ -41,22 +43,24 @@ test_that("validate_model_metadata_schema works", {
 test_that("validate_model_metadata_schema errors for imparsable json", {
   tmp <- withr::local_tempdir()
   testhub <- testthat::test_path(
-    "testdata", "error_hub"
+    "testdata",
+    "error_hub"
   )
 
   fs::dir_copy(testhub, tmp, overwrite = TRUE)
   # muck about
-  cat("!green crayon? {\n",
+  cat(
+    "!green crayon? {\n",
     file = fs::path(tmp, "hub-config", "model-metadata-schema.json"),
     append = TRUE
   )
   suppressMessages({
-    expect_message(out <- validate_model_metadata_schema(hub_path = tmp),
+    expect_message(
+      out <- validate_model_metadata_schema(hub_path = tmp),
       "SyntaxError"
     )
   })
   # NOTE: this needs to be unclassed because otherwise testthat assumes it is
   # an error: https://github.com/hubverse-org/hubAdmin/pull/86/files#r1882552109
   expect_false(unclass(out))
-
 })

--- a/tests/testthat/test-write_config.R
+++ b/tests/testthat/test-write_config.R
@@ -133,9 +133,11 @@ test_that("write_config autoboxing works", {
   config <- hubUtils::read_config(".")
   config_plus_new_round <- append_round(config = config, create_new_round())
 
-  write_config(config_plus_new_round,
+  write_config(
+    config_plus_new_round,
     silent = TRUE,
-    autobox = FALSE, overwrite = TRUE
+    autobox = FALSE,
+    overwrite = TRUE
   )
   expect_false(suppressMessages(validate_config()))
 
@@ -164,8 +166,10 @@ test_that("write_config with autobox = FALSE does not box and issues warning", {
       )
     )
     result <- write_config(
-      config = config, silent = TRUE,
-      autobox = FALSE, overwrite = TRUE
+      config = config,
+      silent = TRUE,
+      autobox = FALSE,
+      overwrite = TRUE
     )
     expect_false(suppressMessages(validate_config()))
   })


### PR DESCRIPTION
## Summary

- Set up [Air](https://posit-dev.github.io/air/) code formatting via `usethis::use_air()`
- Add `format-check.yaml` GitHub Actions workflow to check formatting on PRs
- Update CONTRIBUTING.md with Air setup instructions
- Reformat all R code with `air format .`

Related to hubverse-org/hubDevs#45

## Notes

Air is Posit's new R code formatter. The project-based configuration ensures formatting only applies within this repo - contributors' personal projects remain unaffected.

### ⚠️ Potential lintr failures

If the lint workflow fails on this PR, please ignore those failures for now. Recent changes in lintr (v3.3.0+) may surface pre-existing issues unrelated to this formatting migration. If lint failures occur, please open a separate issue to address them independently.
